### PR TITLE
Generic canvas functions

### DIFF
--- a/src/lib/custom_canvas.ts
+++ b/src/lib/custom_canvas.ts
@@ -1,8 +1,8 @@
 import { fabric } from "fabric"
 import { findLefTopX, findLeftTopY, getObjectSizeWithStroke, getRandomRGB} from './utils'
 import type { Zone } from "./zones";
-import { States } from "../store/state";
 import { get, type Writable } from "svelte/store";
+import { States } from "./states";
 
 
 // Extend fabric.Canvas with custom properties

--- a/src/lib/custom_canvas.ts
+++ b/src/lib/custom_canvas.ts
@@ -3,7 +3,6 @@ import { findLefTopX, findLeftTopY, getObjectSizeWithStroke, getRandomRGB} from 
 import type { Zone } from "./zones";
 import { get, type Writable } from "svelte/store";
 import { States } from "./states";
-import type { IEvent } from "fabric/fabric-impl";
 
 
 // Extend fabric.Canvas with custom properties
@@ -179,7 +178,7 @@ export const makeContour = (coordinates: any, color = getRandomRGB()): ContourWr
 }
 
 export function contourMouseDownEventWrapper(state: Writable<States>, storage: Map<string, Zone>, updateDataStorageFn: (key: string, value: Zone) => void) {
-    return function(options: IEvent<MouseEvent>) {
+    return function(options: fabric.IEvent<MouseEvent>) {
         const targetContour = options.target
         if (!targetContour) {
             console.error('Empty target contour on mouse:down. Options:', options)

--- a/src/lib/custom_canvas.ts
+++ b/src/lib/custom_canvas.ts
@@ -279,7 +279,6 @@ export const drawCanvasPolygons = (extendedCanvas: FabricCanvasWrap, state: Writ
             updateDataStorageFn(targetPolygon.unid, existingContour)
         })
 
-
         contour.unid = feature.id
         contour.notation.forEach((_, idx) => {
             // @ts-ignore

--- a/src/lib/custom_canvas.ts
+++ b/src/lib/custom_canvas.ts
@@ -241,6 +241,11 @@ export const drawCanvasPolygons = (extendedCanvas: FabricCanvasWrap, state: Writ
                 console.error('Unhandled type. Only CustomPolygon on top of fabric.Object has been implemented. Options:', options)
             }
             const targetPolygon = targetContour as CustomPolygon
+            const targetExtendedCanvas: FabricCanvasWrap | undefined = targetContour.canvas as FabricCanvasWrap | undefined
+            if (!targetExtendedCanvas) {
+                console.error('Empty target canvas. Options:', options)
+                return
+            }
             // Recalculate points
             const matrix = targetPolygon.inner.calcTransformMatrix();
             if (!targetPolygon.inner.points) {
@@ -272,8 +277,8 @@ export const drawCanvasPolygons = (extendedCanvas: FabricCanvasWrap, state: Writ
             }
             existingContour.properties.coordinates = targetPolygon.current_points.map((element: { x: number; y: number; }) => {
                 return [
-                    Math.floor(element.x/extendedCanvas.scaleWidth),
-                    Math.floor(element.y/extendedCanvas.scaleHeight)
+                    Math.floor(element.x/targetExtendedCanvas.scaleWidth),
+                    Math.floor(element.y/targetExtendedCanvas.scaleHeight)
                 ]
             }) as [[number, number], [number, number], [number, number], [number, number]]
             updateDataStorageFn(targetPolygon.unid, existingContour)

--- a/src/lib/custom_canvas.ts
+++ b/src/lib/custom_canvas.ts
@@ -125,7 +125,7 @@ export interface ContourWrap {
     current_points?: fabric.Point[] | undefined
 }
 
-class CustomPolygon extends fabric.Polygon implements ContourWrap {
+export class CustomPolygon extends fabric.Polygon implements ContourWrap {
     inner: fabric.Polygon
     unid: string;
     notation: fabric.Text[];
@@ -266,7 +266,7 @@ export const drawCanvasPolygons = (extendedCanvas: FabricCanvasWrap, state: Writ
                 }
                 vertextNotation.set({ left: vertex.x, top: vertex.y })
             })
-            let existingContour = storage.get(contour.unid);
+            let existingContour = storage.get(targetPolygon.unid);
             if (!existingContour) {
                 return
             }
@@ -275,9 +275,11 @@ export const drawCanvasPolygons = (extendedCanvas: FabricCanvasWrap, state: Writ
                     Math.floor(element.x/extendedCanvas.scaleWidth),
                     Math.floor(element.y/extendedCanvas.scaleHeight)
                 ]
-            })  as [[number, number], [number, number], [number, number], [number, number]]
-            updateDataStorageFn(contour.unid, existingContour)
+            }) as [[number, number], [number, number], [number, number], [number, number]]
+            updateDataStorageFn(targetPolygon.unid, existingContour)
         })
+
+
         contour.unid = feature.id
         contour.notation.forEach((_, idx) => {
             // @ts-ignore

--- a/src/lib/custom_canvas.ts
+++ b/src/lib/custom_canvas.ts
@@ -182,16 +182,19 @@ export function contourMouseDownEventWrapper(state: Writable<States>, storage: M
     return function(options: IEvent<MouseEvent>) {
         const targetContour = options.target
         if (!targetContour) {
-            console.error('Empty target contour. Options:', options)
+            console.error('Empty target contour on mouse:down. Options:', options)
             return
         }
         if (!(targetContour instanceof CustomPolygon)) {
-            console.error('Unhandled type. Only CustomPolygon on top of fabric.Object has been implemented. Options:', options)
+            console.error('Unhandled type. Only CustomPolygon on top of fabric.Object has been implemented. Event: mouse:down. Options:', options)
+            return
         }
         const targetPolygon = targetContour as CustomPolygon
         const targetExtendedCanvas: FabricCanvasWrap | undefined = targetContour.canvas as FabricCanvasWrap | undefined
         if (!targetExtendedCanvas) {
-            console.error('Empty target canvas. Options:', options)
+            // Could be triggered when object is deleted via click.
+            // @todo: consider to re-impelement
+            console.error('Empty target canvas on mouse:down. Options:', options)
             return
         }
         options.e.preventDefault();
@@ -209,7 +212,7 @@ export function contourMouseDownEventWrapper(state: Writable<States>, storage: M
                     return
                 }
                 if (!targetPolygon.current_points) {
-                    console.error('No current points in target polygon. Options:', options)
+                    console.error('No current points in target polygon. Event: mouse:down. Options:', options)
                     return
                 }
                 existingContour.properties.coordinates = targetPolygon.current_points.map((element: { x: number; y: number; }) => {
@@ -229,22 +232,23 @@ export function contourModifiedEventWrapper(storage: Map<string, Zone>, updateDa
     return function(options: fabric.IEvent<Event>) {
         const targetContour = options.target
         if (!targetContour) {
-            console.error('Empty target contour. Options:', options)
+            console.error('Empty target contour on modified. Options:', options)
             return
         }
         if (!(targetContour instanceof CustomPolygon)) {
-            console.error('Unhandled type. Only CustomPolygon on top of fabric.Object has been implemented. Options:', options)
+            console.error('Unhandled type. Only CustomPolygon on top of fabric.Object has been implemented. Event: modified. Options:', options)
+            return
         }
         const targetPolygon = targetContour as CustomPolygon
         const targetExtendedCanvas: FabricCanvasWrap | undefined = targetContour.canvas as FabricCanvasWrap | undefined
         if (!targetExtendedCanvas) {
-            console.error('Empty target canvas. Options:', options)
+            console.error('Empty target canvas on modified. Options:', options)
             return
         }
         // Recalculate points
         const matrix = targetPolygon.inner.calcTransformMatrix();
         if (!targetPolygon.inner.points) {
-            console.error('No points in fabric.Polygon. Options:', options)
+            console.error('No points in fabric.Polygon. Event: modified. Options:', options)
             return
         }
         const transformedPoints = targetPolygon.inner.points.map(function (p) {

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -7,3 +7,8 @@ export enum States {
     DeletingZoneMap,
     PickPolygon
 }
+
+export enum SubscriberState {
+    Init = 'init',
+    ReInit = 're-init'
+}

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -1,0 +1,9 @@
+export enum States {
+    AddingZoneCanvas = 1,
+    AddingZoneMap,
+    Waiting,
+    EditingZone,
+    DeletingZoneCanvas,
+    DeletingZoneMap,
+    PickPolygon
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -361,14 +361,13 @@
                 }) as [[number, number], [number, number], [number, number], [number, number]]
                 updateDataStorage(targetPolygon.unid, existingContour)
             })
-
-
-            //@ts-ignore
+            
             contour.unid = new UUIDv4().generate()
             contour.notation.forEach((_, idx) => {
                 //@ts-ignore
                 contour.notation[idx].text_id = contour.unid
             })
+            
             const newContour = {
                 type: 'Feature',
                 id: contour.unid,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
     import CanvasComponent from '../components/CanvasComponent.svelte'
     import Switchers from '../components/Switchers.svelte'
     import ConfigurationStorage from '../components/ConfigurationStorage.svelte';
-    import { States, state, mjpegReady, dataReady, apiUrlStore, changeAPI } from '../store/state.js'
+    import { state, mjpegReady, dataReady, apiUrlStore, changeAPI } from '../store/state.js'
     import { type DrawCreateEvent, type DrawUpdateEvent } from "@mapbox/mapbox-gl-draw"
     import { dataStorage, addZoneFeature, updateDataStorage, deleteFromDataStorage, clearDataStorage, resetZoneSpatialInfo, deattachCanvasFromSpatial } from '../store/data_storage'
     import { map, draw } from '../store/map'
@@ -17,6 +17,7 @@
 	import { ExtendedCanvas, makeContour, type FabricCanvasWrap, verticesChars, drawCanvasPolygons, type ContourPoint } from '$lib/custom_canvas';
 	import type { ZoneFeature, ZonesCollection } from '$lib/zones';
 	import { saveTOML } from '$lib/rest_api_mutations';
+	import { States } from '$lib/states';
 
     const { apiURL } = apiUrlStore
     let initialAPIURL = $apiURL

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,6 +21,9 @@
     const { apiURL } = apiUrlStore
     let initialAPIURL = $apiURL
 
+    let stateVariable: States;
+    state.subscribe((value) => stateVariable = value)
+
 	const title = 'Rust Road Traffic UI'
     // let scaleWidth: number, scaleHeight: number
     let canvas: HTMLCanvasElement
@@ -55,6 +58,7 @@
             if (value === true) {
                 // Initialize canvas if it's empty (due the MJPEG error)
                 if (fbCanvas === undefined || fbCanvas == null) {
+                    console.log(`Prepare canvas: ${subType}`)
                     initializeCanvas()
                 }
             }
@@ -122,7 +126,7 @@
 
         // Override DeleteClickedZone click event
         DeleteClickedZone.onClick = (s: any, e: any) => {
-            if (e.featureTarget && $state === States.DeletingZoneMap) {
+            if (e.featureTarget && stateVariable === States.DeletingZoneMap) {
                 const mapTargetFeature = e.featureTarget
                 const spatialID = mapTargetFeature.properties.id
                 state.set(States.Waiting)
@@ -208,26 +212,26 @@
         fbCanvasParent = document.getElementsByClassName('custom-container-canvas')[0];
         fbCanvasParent.id = "fbcanvas";
         fbCanvas.on('selection:created', (options: any) => {
-            if ($state === States.DeletingZoneCanvas) {
+            if (stateVariable === States.DeletingZoneCanvas) {
                 deleteZoneFromCanvas(fbCanvas, options.selected[0].unid);
                 state.set(States.Waiting)
             }
         })
         fbCanvas.on('selection:updated', (options: any) => {
-            if ($state === States.DeletingZoneCanvas) {
+            if (stateVariable === States.DeletingZoneCanvas) {
                 deleteZoneFromCanvas(fbCanvas, options.selected[0].unid);
                 state.set(States.Waiting)
             }
         })
         fbCanvas.on('mouse:move', (options: any) => {
-            if (fbCanvas.contourTemporary[0] !== null && fbCanvas.contourTemporary[0] !== undefined && $state === States.AddingZoneCanvas) {
+            if (fbCanvas.contourTemporary[0] !== null && fbCanvas.contourTemporary[0] !== undefined && stateVariable === States.AddingZoneCanvas) {
                 const clicked = getClickPoint(fbCanvas, options)
                 fbCanvas.contourTemporary[fbCanvas.contourTemporary.length - 1].set({ x2: clicked.x, y2: clicked.y })
                 fbCanvas.renderAll()
             }
         });
         fbCanvas.on('mouse:down', (options: any) => {
-            if ($state !== States.AddingZoneCanvas) {
+            if (stateVariable !== States.AddingZoneCanvas) {
                 return
             }
             fbCanvas.selection = false
@@ -273,10 +277,10 @@
                 // Handle right-click
                 // Turn on "Edit" mode
                 if (options.button === 3) {
-                    if ($state !== States.EditingZone) {
-                        $state = States.EditingZone;
+                    if (stateVariable !== States.EditingZone) {
+                        state.set(States.EditingZone);
                     } else {
-                        $state = States.Waiting;
+                        state.set(States.Waiting);
                         let existingContour = $dataStorage.get(contour.unid);
                         if (!existingContour) {
                             return
@@ -402,7 +406,7 @@
     }
 
     const stateAddToCanvas = () => {
-        if ($state !== States.AddingZoneCanvas) {
+        if (stateVariable !== States.AddingZoneCanvas) {
             state.set(States.AddingZoneCanvas)
             $draw.changeMode('draw_restricted_polygon');
         } else {
@@ -412,7 +416,7 @@
     }
 
     const stateAddToMap = () => {
-        if ($state !== States.AddingZoneMap) {
+        if (stateVariable !== States.AddingZoneMap) {
             state.set(States.AddingZoneMap)
             $draw.changeMode('draw_restricted_polygon');
         } else {
@@ -422,7 +426,7 @@
     }
 
     const stateDelFromCanvas = () => {
-        if ($state !== States.DeletingZoneCanvas) {
+        if (stateVariable !== States.DeletingZoneCanvas) {
             state.set(States.DeletingZoneCanvas)
         } else {
             state.set(States.Waiting)
@@ -430,7 +434,7 @@
     }
 
     const stateDelFromMap = () => {
-        if ($state !== States.DeletingZoneMap) {
+        if (stateVariable !== States.DeletingZoneMap) {
             state.set(States.DeletingZoneMap)
             $draw.changeMode('delete_zone');
         } else {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -329,8 +329,6 @@
             })
             //@ts-ignore
             contour.unid = new UUIDv4().generate()
-            //@ts-ignore
-            contour.inner.unid = contour.unid
             contour.notation.forEach((_, idx) => {
                 //@ts-ignore
                 contour.notation[idx].text_id = contour.unid

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -322,7 +322,11 @@
                     console.error('Unhandled type. Only CustomPolygon on top of fabric.Object has been implemented. Options:', options)
                 }
                 const targetPolygon = targetContour as CustomPolygon
-                
+                const targetExtendedCanvas: FabricCanvasWrap | undefined = targetContour.canvas as FabricCanvasWrap | undefined
+                if (!targetExtendedCanvas) {
+                    console.error('Empty target canvas. Options:', options)
+                    return
+                }
                 // Recalculate points
                 const matrix = targetPolygon.inner.calcTransformMatrix();
                 if (!targetPolygon.inner.points) {
@@ -355,8 +359,8 @@
                 }
                 existingContour.properties.coordinates = targetPolygon.current_points.map((element: { x: number; y: number; }) => {
                     return [
-                        Math.floor(element.x/fbCanvas.scaleWidth),
-                        Math.floor(element.y/fbCanvas.scaleHeight)
+                        Math.floor(element.x/targetExtendedCanvas.scaleWidth),
+                        Math.floor(element.y/targetExtendedCanvas.scaleHeight)
                     ]
                 }) as [[number, number], [number, number], [number, number], [number, number]]
                 updateDataStorage(targetPolygon.unid, existingContour)
@@ -367,7 +371,7 @@
                 //@ts-ignore
                 contour.notation[idx].text_id = contour.unid
             })
-            
+
             const newContour = {
                 type: 'Feature',
                 id: contour.unid,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,7 +17,7 @@
 	import { ExtendedCanvas, makeContour, type FabricCanvasWrap, verticesChars, drawCanvasPolygons, type ContourPoint } from '$lib/custom_canvas';
 	import type { ZoneFeature, ZonesCollection } from '$lib/zones';
 	import { saveTOML } from '$lib/rest_api_mutations';
-	import { States } from '$lib/states';
+	import { States, SubscriberState } from '$lib/states';
 
     const { apiURL } = apiUrlStore
     let initialAPIURL = $apiURL
@@ -48,11 +48,6 @@
     ])
     const cancelActionUnexpected = 'Unexpected action'
     $: cancelActionText = cancelActionTexts.get($state)
-
-    enum SubscriberState {
-        Init = 'init',
-        ReInit = 're-init'
-    }
 
     const initSubscribers = (subType: SubscriberState) => {
         unsubscribeMJPEG = mjpegReady.subscribe(value => {

--- a/src/store/data_storage.ts
+++ b/src/store/data_storage.ts
@@ -60,7 +60,7 @@ export const deattachCanvasFromSpatial = (storage: Map<string, Zone>, mdraw: Map
     return
   }
   if (!zone.properties.spatial_object_id) {
-    console.error(`ID '${zone.id}' should have 'spatial_object_id' in prpetries, but it has not`)
+    console.error(`ID '${zone.id}' should have 'spatial_object_id' in properties, but it has not`)
     return
   }
   const drawFeature = mdraw.get(zone.properties.spatial_object_id);

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,15 +1,6 @@
+import { States } from '$lib/states';
 import { derived, writable, type Writable } from 'svelte/store'
 // import { apiURL } from '../store/polygons'
-
-export enum States {
-    AddingZoneCanvas = 1,
-    AddingZoneMap,
-    Waiting,
-    EditingZone,
-    DeletingZoneCanvas,
-    DeletingZoneMap,
-    PickPolygon
-}
 
 export const state = writable(States.Waiting);
 


### PR DESCRIPTION
- Separate enums for state type
- Reduce code duplicates by generalize contour event listeners
- Subscriber for state (to eliminate usage of `$state` or `get(state)` as "getter") in page.svelte