### PR TITLE
Block interface on MJPEG reload + Remove canvas initialization from +page.svelte

### DIFF
--- a/src/components/CanvasComponent.svelte
+++ b/src/components/CanvasComponent.svelte
@@ -181,13 +181,15 @@
 </script>
 
 <div id="mjpeg" class={"mjpeg-canvas" + ' ' + klass}>
-    <div id="loading-message" class={$imgSrcLoaded? 'd-none' : 'loading d-block'}>
-        Please wait until image is loaded
-    </div>
     <!-- svelte-ignore a11y-missing-attribute -->
-    <img id="fit_img" src="{initialAPIURL}/live_streaming" width="500" height="500" class={$imgSrcLoaded? 'd-block' : 'd-none'} on:load={imageLoaded}>
+    <img id="fit_img" src="{initialAPIURL}/live_streaming" width="500" height="500" on:load={imageLoaded}>
     <!-- <img id="fit_img" src="https://pngimg.com/uploads/google/google_PNG19632.png" width="500" height="500" on:load={imageLoaded}> -->
-    <canvas id="fit_canvas" class={$imgSrcLoaded? 'd-block' : 'd-none'}></canvas>
+    <canvas id="fit_canvas" ></canvas>
+    <div id="loading-message" class={$imgSrcLoaded? 'd-none' : 'd-block'}>
+        <div class={$imgSrcLoaded? 'd-none' : 'loading d-block'}>
+            Please wait until image is loaded
+        </div>
+    </div>
 </div>
 
 
@@ -199,6 +201,7 @@
         display: none;
     }
     #mjpeg {
+        position: relative;
         grid-area: A;
         background-color: rgba(128, 128, 128, 0.8);
     }
@@ -218,16 +221,21 @@
         justify-content: center;
         align-items: center;
         position: absolute;
-        top: 40%;
+        top: 0;
+        height: 100%;
+        width: 100%;
+        background-color: rgba(128, 128, 128, 0.8);
+    }
+    .loading {
+        position: absolute;
+        top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
         background-color: rgba(128, 128, 128, 0.8);
         padding: 0.66665rem;
         border-radius: 5px;
         pointer-events: none;
-    }
-    .loading {
-       font-size: 2rem;
+        font-size: 2rem;
     }
     .loading:after {
         overflow: hidden;

--- a/src/components/CanvasComponent.svelte
+++ b/src/components/CanvasComponent.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
     import { onMount, onDestroy } from 'svelte'
-    import { mjpegReady, apiUrlStore, changeAPI } from '../store/state.js'
+    import { fabric } from "fabric"
+    import { canvasReady, canvasState, apiUrlStore, changeAPI, state } from '../store/state.js'
+	import { ExtendedCanvas, prepareContour, verticesChars, type FabricCanvasWrap } from '$lib/custom_canvas.js';
+	import { States } from '$lib/states.js';
+	import { getClickPoint, rgba2array } from '$lib/utils.js';
+	import { dataStorage, deattachCanvasFromSpatial, deleteFromDataStorage, updateDataStorage } from '../store/data_storage.js';
+	import { draw } from '../store/map.js';
 
     export let klass: string = ''
 
     const { apiURL } = apiUrlStore
     let initialAPIURL = `${$apiURL}`
-
+    
+    let stateVariable: States;
+    state.subscribe((value) => stateVariable = value)
+    
     const imageLoaded = () => {
-        mjpegReady.set(true)
+        console.log('Image source reloaded')
+        const fbCanvas = initializeCanvas()
+        canvasState.set(fbCanvas)
+        canvasReady.set(true)
     }
 
     const unsubApiChange = changeAPI.subscribe(value => {
@@ -24,6 +36,140 @@
     onDestroy(() => {
         unsubApiChange()
     });
+
+    const deleteZoneFromCanvas = (extendedCanvas: any, zoneID: string) => {
+        // Пересмотреть поведение
+        extendedCanvas.getObjects().forEach( (contour: { unid: string; }) => {
+            if (contour.unid === zoneID) {
+                extendedCanvas.remove(contour)
+                return
+            }
+        })
+        extendedCanvas.getObjects().forEach( (textObject: { text_id: string; }) => {
+            if (textObject.text_id === zoneID) {
+                extendedCanvas.remove(textObject)
+                return
+            }
+        })
+        deattachCanvasFromSpatial($dataStorage, $draw, zoneID)
+        deleteFromDataStorage(zoneID)
+    }
+    
+    const initializeCanvas = (): FabricCanvasWrap => {
+        const canvasElem = document.getElementById('fit_canvas') as HTMLCanvasElement
+        const imageElem = document.getElementById('fit_img') as HTMLImageElement
+        canvasElem.width = imageElem.clientWidth
+        canvasElem.height = imageElem.clientHeight
+        const fbCanvas = new ExtendedCanvas('fit_canvas', {
+            containerClass: 'custom-container-canvas',
+            fireRightClick: true,  
+            fireMiddleClick: true, 
+            stopContextMenu: true
+        })
+        fbCanvas.scaleWidth = imageElem.clientWidth/imageElem.naturalWidth
+        fbCanvas.scaleHeight = imageElem.clientHeight/imageElem.naturalHeight
+        const fbCanvasParent = document.getElementsByClassName('custom-container-canvas')[0];
+        fbCanvasParent.id = "fbcanvas";
+        fbCanvas.on('selection:created', (options: any) => {
+            if (stateVariable === States.DeletingZoneCanvas) {
+                deleteZoneFromCanvas(fbCanvas, options.selected[0].unid);
+                state.set(States.Waiting)
+            }
+        })
+        fbCanvas.on('selection:updated', (options: any) => {
+            if (stateVariable === States.DeletingZoneCanvas) {
+                deleteZoneFromCanvas(fbCanvas, options.selected[0].unid);
+                state.set(States.Waiting)
+            }
+        })
+        fbCanvas.on('mouse:move', (options: any) => {
+            if (fbCanvas.contourTemporary[0] !== null && fbCanvas.contourTemporary[0] !== undefined && stateVariable === States.AddingZoneCanvas) {
+                const clicked = getClickPoint(fbCanvas, options)
+                fbCanvas.contourTemporary[fbCanvas.contourTemporary.length - 1].set({ x2: clicked.x, y2: clicked.y })
+                fbCanvas.renderAll()
+            }
+        });
+        fbCanvas.on('mouse:down', (options: any) => {
+            if (stateVariable !== States.AddingZoneCanvas) {
+                return
+            }
+            fbCanvas.selection = false
+            const clicked = getClickPoint(fbCanvas, options)
+            fbCanvas.contourFinalized.push({ x: clicked.x, y: clicked.y })
+            const points = [clicked.x, clicked.y, clicked.x, clicked.y]
+            const newLine = new fabric.Line(points, {
+                strokeWidth: 3,
+                selectable: false,
+                stroke: 'purple',
+            })
+            const newVertexNotation = new fabric.Text(verticesChars[fbCanvas.contourFinalized.length-1], {
+                left: clicked.x,
+                top: clicked.y,
+                fontSize: 24,
+                fontFamily: 'Roboto',
+                fill: 'purple',
+                shadow: '0 0 10px rgba(255, 255, 255, 0.7)',
+                stroke: 'rgb(0, 0, 0)',
+                strokeWidth: 0.9,
+            })
+            fbCanvas.contourNotationTemporary.push(newVertexNotation)
+            fbCanvas.contourTemporary.push(newLine)
+            fbCanvas.add(newLine)
+            fbCanvas.add(newVertexNotation)
+            fbCanvas.on('mouse:up', function (options: any) {
+                fbCanvas.selection = true;
+            })
+            if (fbCanvas.contourFinalized.length <= 3) {
+                // Return till there are four points in contour atleast
+                return
+            }
+            fbCanvas.contourTemporary.forEach((value) => {
+                fbCanvas.remove(value)
+            })
+            fbCanvas.contourNotationTemporary.forEach((value) => {
+                fbCanvas.remove(value)
+            })
+
+            const contour = prepareContour(fbCanvas.contourFinalized, state, $dataStorage, updateDataStorage)
+
+            const newContour = {
+                type: 'Feature',
+                id: contour.unid,
+                properties: {
+                    color_rgb: rgba2array(contour.inner.stroke),
+                    color_rgb_str: contour.inner.stroke ? contour.inner.stroke : "rgb(0, 0, 0)",
+                    //@ts-ignore
+                    coordinates: contour.inner.current_points.map((element: { x: number; y: number; }) => {
+                        return [
+                            Math.floor(element.x/fbCanvas.scaleWidth),
+                            Math.floor(element.y/fbCanvas.scaleHeight)
+                        ]
+                    }),
+                    road_lane_direction: -1,
+                    road_lane_num: -1,
+                    spatial_object_id: undefined
+                },
+                geometry: {
+                    type: 'Polygon',
+                    coordinates: [[[-1, -1], [-1, -1], [-1, -1], [-1, -1], [-1, -1]]]
+                }
+            }
+            updateDataStorage(contour.unid, newContour)
+            fbCanvas.add(contour.inner)
+            contour.notation.forEach((vertextNotation: fabric.Text) => {
+                fbCanvas.add(vertextNotation)
+            })
+            fbCanvas.renderAll()
+            fbCanvas.contourTemporary = []
+            fbCanvas.contourNotationTemporary = []
+            fbCanvas.contourFinalized = []
+            state.set(States.Waiting)
+            $draw.changeMode('simple_select')
+        })
+
+        return fbCanvas
+    }
+
 </script>
 
 <div id="mjpeg" class={"mjpeg-canvas" + ' ' + klass}>

--- a/src/components/CanvasComponent.svelte
+++ b/src/components/CanvasComponent.svelte
@@ -18,8 +18,11 @@
     
     const imageLoaded = () => {
         console.log('Image source reloaded')
-        const fbCanvas = initializeCanvas()
-        canvasState.set(fbCanvas)
+        if ($canvasState === undefined || $canvasState == null) {
+            console.log(`Prepare canvas on first initialization`)
+            const fbCanvas = initializeCanvas()
+            canvasState.set(fbCanvas)
+        }
         canvasReady.set(true)
     }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -272,13 +272,13 @@
     <div id="main_workspace">
         <div id="left_workspace">
             <CanvasComponent klass={!canvasFocused && mapFocused ? 'blurred noselect' : ''}/>
-            <ConfigurationStorage dataReady={dataReady} data={dataStorageFiltered} klass={canvasFocused || mapFocused ? 'blurred noselect' : ''}/>
+            <ConfigurationStorage dataReady={dataReady} data={dataStorageFiltered} klass={!($canvasReady) || (canvasFocused || mapFocused) ? 'blurred noselect' : ''}/>
             <div class="overlay" style="{!canvasFocused && mapFocused ? 'display: block;' : 'display: none;'}">
                 Press ESC to cancel '{cancelActionText !== undefined? cancelActionText : cancelActionUnexpected}' mode
             </div>
         </div>
         <div id="right_workspace">
-            <MapComponent bind:this={mapComponent} klass={canvasFocused && !mapFocused ? 'blurred noselect' : ''}/>
+            <MapComponent bind:this={mapComponent} klass={!($canvasReady) || (canvasFocused && !mapFocused) ? 'blurred noselect' : ''}/>
             <div class="overlay" style="{canvasFocused && !mapFocused ? 'display: block;' : 'display: none;'}">
                 Press ESC to cancel '{cancelActionText !== undefined? cancelActionText : cancelActionUnexpected}' mode
             </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,20 +1,18 @@
 <script lang="ts">
     import { onMount, onDestroy } from 'svelte'
 	import type { Unsubscriber } from 'svelte/store';
-    import { fabric } from "fabric"
     import MapComponent from '../components/MapComponent.svelte'
     import CanvasComponent from '../components/CanvasComponent.svelte'
     import Switchers from '../components/Switchers.svelte'
     import ConfigurationStorage from '../components/ConfigurationStorage.svelte';
-    import { state, mjpegReady, dataReady, apiUrlStore, changeAPI } from '../store/state.js'
+    import { state, canvasReady, dataReady, canvasState, apiUrlStore, changeAPI } from '../store/state.js'
     import { type DrawCreateEvent, type DrawUpdateEvent } from "@mapbox/mapbox-gl-draw"
-    import { dataStorage, addZoneFeature, updateDataStorage, deleteFromDataStorage, clearDataStorage, resetZoneSpatialInfo, deattachCanvasFromSpatial } from '../store/data_storage'
+    import { dataStorage, addZoneFeature, updateDataStorage, clearDataStorage, resetZoneSpatialInfo } from '../store/data_storage'
     import { map, draw } from '../store/map'
     import { EMPTY_POLYGON_RGB } from '../lib/gl_draw_styles.js'
     import { DeleteClickedZone } from '../lib/custom_delete.js'
-    import { getClickPoint, rgba2array } from '../lib/utils'
 	import type { Polygon } from 'geojson';
-	import { ExtendedCanvas, type FabricCanvasWrap, verticesChars, drawCanvasPolygons, prepareContour } from '$lib/custom_canvas';
+	import { type FabricCanvasWrap, drawCanvasPolygons } from '$lib/custom_canvas';
 	import type { ZoneFeature, ZonesCollection } from '$lib/zones';
 	import { saveTOML } from '$lib/rest_api_mutations';
 	import { States, SubscriberState } from '$lib/states';
@@ -26,13 +24,9 @@
     state.subscribe((value) => stateVariable = value)
 
 	const title = 'Rust Road Traffic UI'
-    // let scaleWidth: number, scaleHeight: number
-    let canvas: HTMLCanvasElement
-    let image: HTMLImageElement
-    let fbCanvas: FabricCanvasWrap
-    let fbCanvasParent: Element
+    
     let mapComponent: any
-    let unsubscribeMJPEG: Unsubscriber
+    let unsubscribeCanvas: Unsubscriber
     let unsubscribeGeoData: Unsubscriber
     $: canvasFocused = ($state === States.AddingZoneCanvas || $state === States.DeletingZoneCanvas)
     $: mapFocused = ($state === States.AddingZoneMap || $state === States.DeletingZoneMap)
@@ -50,23 +44,16 @@
     $: cancelActionText = cancelActionTexts.get($state)
 
     const initSubscribers = (subType: SubscriberState) => {
-        unsubscribeMJPEG = mjpegReady.subscribe(value => {
-            if (value === true) {
-                // Initialize canvas if it's empty (due the MJPEG error)
-                if (fbCanvas === undefined || fbCanvas == null) {
-                    console.log(`Prepare canvas: ${subType}`)
-                    initializeCanvas()
-                }
-            }
+        unsubscribeCanvas = canvasReady.subscribe(value => {
             if (value === true && $dataReady == true) {
                 console.log(`MJPEG is loaded after geo data: ${subType}`)
-                drawCanvasPolygons(fbCanvas, state, $dataStorage, updateDataStorage)
+                drawCanvasPolygons($canvasState, state, $dataStorage, updateDataStorage)
             }
         })
         unsubscribeGeoData = dataReady.subscribe(value => {
-            if (value === true && $mjpegReady == true) {
+            if (value === true && $canvasReady == true) {
                 console.log(`MJPEG is loaded before geo data: '${subType}'`)
-                drawCanvasPolygons(fbCanvas, state, $dataStorage, updateDataStorage)
+                drawCanvasPolygons($canvasState, state, $dataStorage, updateDataStorage)
             }
         })
         const endpoint = `${initialAPIURL}/api/polygons/geojson`
@@ -79,7 +66,6 @@
                     addZoneFeature(feature)
                 });
                 if (subType === SubscriberState.ReInit) {
-                    console.log('loaded')
                     mapComponent.drawGeoPolygons($draw, $dataStorage);
                 } else {
                     $map.on('load', () => {
@@ -99,16 +85,16 @@
             initialAPIURL = value
 
             /* Clean UP */
-            mjpegReady.set(false)
+            canvasReady.set(false)
             dataReady.set(false)
-            unsubscribeMJPEG()
+            unsubscribeCanvas()
             unsubscribeGeoData()
             clearDataStorage()
-            if (fbCanvas !== undefined && fbCanvas != null) {
+            if ($canvasState !== undefined && $canvasState != null) {
                 //@ts-ignore
-                fbCanvas.getObjects().forEach( (contour: { unid: string; }) => {
+                $canvasState.getObjects().forEach( (contour: { unid: string; }) => {
                     //@ts-ignore
-                    fbCanvas.remove(contour);
+                    $canvasState.remove(contour);
                 })
             }
             $draw.deleteAll()
@@ -165,16 +151,16 @@
 
     onDestroy(() => {
         console.log('Destroyed')
-        mjpegReady.set(false)
+        canvasReady.set(false)
         dataReady.set(false)
-        unsubscribeMJPEG()
+        unsubscribeCanvas()
         unsubscribeGeoData()
         unsubApiChange()
     });
 
     function keyPress(e: KeyboardEvent) { 
         if (e.key === "Escape") {
-            resetCurrentCanvasDrawing(fbCanvas)
+            resetCurrentCanvasDrawing($canvasState)
             $draw.changeMode('simple_select')
             state.set(States.Waiting)
         }
@@ -191,119 +177,6 @@
         // @ts-ignore
         const collapsibleInstances = M.Collapsible.init(collapsibleElem, {})
 	}
-    
-    const initializeCanvas = () => {
-        canvas = document.getElementById('fit_canvas') as HTMLCanvasElement
-        image = document.getElementById('fit_img') as HTMLImageElement
-        canvas.width = image.clientWidth
-        canvas.height = image.clientHeight
-        fbCanvas = new ExtendedCanvas('fit_canvas', {
-            containerClass: 'custom-container-canvas',
-            fireRightClick: true,  
-            fireMiddleClick: true, 
-            stopContextMenu: true
-        })
-        fbCanvas.scaleWidth = image.clientWidth/image.naturalWidth
-        fbCanvas.scaleHeight = image.clientHeight/image.naturalHeight
-        fbCanvasParent = document.getElementsByClassName('custom-container-canvas')[0];
-        fbCanvasParent.id = "fbcanvas";
-        fbCanvas.on('selection:created', (options: any) => {
-            if (stateVariable === States.DeletingZoneCanvas) {
-                deleteZoneFromCanvas(fbCanvas, options.selected[0].unid);
-                state.set(States.Waiting)
-            }
-        })
-        fbCanvas.on('selection:updated', (options: any) => {
-            if (stateVariable === States.DeletingZoneCanvas) {
-                deleteZoneFromCanvas(fbCanvas, options.selected[0].unid);
-                state.set(States.Waiting)
-            }
-        })
-        fbCanvas.on('mouse:move', (options: any) => {
-            if (fbCanvas.contourTemporary[0] !== null && fbCanvas.contourTemporary[0] !== undefined && stateVariable === States.AddingZoneCanvas) {
-                const clicked = getClickPoint(fbCanvas, options)
-                fbCanvas.contourTemporary[fbCanvas.contourTemporary.length - 1].set({ x2: clicked.x, y2: clicked.y })
-                fbCanvas.renderAll()
-            }
-        });
-        fbCanvas.on('mouse:down', (options: any) => {
-            if (stateVariable !== States.AddingZoneCanvas) {
-                return
-            }
-            fbCanvas.selection = false
-            const clicked = getClickPoint(fbCanvas, options)
-            fbCanvas.contourFinalized.push({ x: clicked.x, y: clicked.y })
-            const points = [clicked.x, clicked.y, clicked.x, clicked.y]
-            const newLine = new fabric.Line(points, {
-                strokeWidth: 3,
-                selectable: false,
-                stroke: 'purple',
-            })
-            const newVertexNotation = new fabric.Text(verticesChars[fbCanvas.contourFinalized.length-1], {
-                left: clicked.x,
-                top: clicked.y,
-                fontSize: 24,
-                fontFamily: 'Roboto',
-                fill: 'purple',
-                shadow: '0 0 10px rgba(255, 255, 255, 0.7)',
-                stroke: 'rgb(0, 0, 0)',
-                strokeWidth: 0.9,
-            })
-            fbCanvas.contourNotationTemporary.push(newVertexNotation)
-            fbCanvas.contourTemporary.push(newLine)
-            fbCanvas.add(newLine)
-            fbCanvas.add(newVertexNotation)
-            fbCanvas.on('mouse:up', function (options: any) {
-                fbCanvas.selection = true;
-            })
-            if (fbCanvas.contourFinalized.length <= 3) {
-                // Return till there are four points in contour atleast
-                return
-            }
-            fbCanvas.contourTemporary.forEach((value) => {
-                fbCanvas.remove(value)
-            })
-            fbCanvas.contourNotationTemporary.forEach((value) => {
-                fbCanvas.remove(value)
-            })
-
-            const contour = prepareContour(fbCanvas.contourFinalized, state, $dataStorage, updateDataStorage)
-
-            const newContour = {
-                type: 'Feature',
-                id: contour.unid,
-                properties: {
-                    color_rgb: rgba2array(contour.inner.stroke),
-                    color_rgb_str: contour.inner.stroke ? contour.inner.stroke : "rgb(0, 0, 0)",
-                    //@ts-ignore
-                    coordinates: contour.inner.current_points.map((element: { x: number; y: number; }) => {
-                        return [
-                            Math.floor(element.x/fbCanvas.scaleWidth),
-                            Math.floor(element.y/fbCanvas.scaleHeight)
-                        ]
-                    }),
-                    road_lane_direction: -1,
-                    road_lane_num: -1,
-                    spatial_object_id: undefined
-                },
-                geometry: {
-                    type: 'Polygon',
-                    coordinates: [[[-1, -1], [-1, -1], [-1, -1], [-1, -1], [-1, -1]]]
-                }
-            }
-            updateDataStorage(contour.unid, newContour)
-            fbCanvas.add(contour.inner)
-            contour.notation.forEach((vertextNotation: fabric.Text) => {
-                fbCanvas.add(vertextNotation)
-            })
-            fbCanvas.renderAll()
-            fbCanvas.contourTemporary = []
-            fbCanvas.contourNotationTemporary = []
-            fbCanvas.contourFinalized = []
-            state.set(States.Waiting)
-            $draw.changeMode('simple_select')
-        })
-    }
 
     const resetCurrentCanvasDrawing = (extendedCanvas: FabricCanvasWrap) => {
         extendedCanvas.contourTemporary.forEach((value) => {
@@ -315,24 +188,6 @@
         extendedCanvas.contourTemporary = []
         extendedCanvas.contourNotationTemporary = []
         extendedCanvas.contourFinalized = []
-    }
-    
-    const deleteZoneFromCanvas = (extendedCanvas: any, zoneID: string) => {
-        // Пересмотреть поведение
-        extendedCanvas.getObjects().forEach( (contour: { unid: string; }) => {
-            if (contour.unid === zoneID) {
-                extendedCanvas.remove(contour)
-                return
-            }
-        })
-        extendedCanvas.getObjects().forEach( (textObject: { text_id: string; }) => {
-            if (textObject.text_id === zoneID) {
-                extendedCanvas.remove(textObject)
-                return
-            }
-        })
-        deattachCanvasFromSpatial($dataStorage, $draw, zoneID)
-        deleteFromDataStorage(zoneID)
     }
 
     const stateAddToCanvas = () => {

--- a/src/store/map.ts
+++ b/src/store/map.ts
@@ -1,11 +1,11 @@
 import { writable, type Writable } from 'svelte/store';
 import type { Map as MMap } from 'maplibre-gl';
 import MapboxDraw from "@mapbox/mapbox-gl-draw"
-import { CUSTOM_GL_DRAW_STYLES } from '../lib/gl_draw_styles.js'
-import { PolygonFourPointsOnly } from '../lib/custom_poly.js'
-import { DeleteClickedZone } from '../lib/custom_delete.js'
+import { CUSTOM_GL_DRAW_STYLES } from '$lib/gl_draw_styles.js'
+import { PolygonFourPointsOnly } from '$lib/custom_poly.js'
+import { DeleteClickedZone } from '$lib/custom_delete.js'
 
-export const map: Writable<MMap> = writable();
+export const map: Writable<MMap> = writable()
 export const draw: Writable<MapboxDraw> = writable(new MapboxDraw({
     userProperties: true,
     displayControlsDefault: false,

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,10 +1,12 @@
 import { States } from '$lib/states';
 import { derived, writable, type Writable } from 'svelte/store'
+import type { FabricCanvasWrap } from '$lib/custom_canvas';
 // import { apiURL } from '../store/polygons'
 
+export const canvasState: Writable<FabricCanvasWrap> = writable()
 export const state = writable(States.Waiting);
 
-export const mjpegReady = writable(false)
+export const canvasReady = writable(false)
 export const dataReady = writable(false)
 
 const defaultSchema = 'http'


### PR DESCRIPTION
- Put blur effect on spatial map and settings when canvas component is not ready
- Add explicit message about MJPEG loading
- Move fabric.Canvas initialization to canvas component