### PR TITLE
[FEATURE] Allow no map tiles + save settings to localStorage

### DIFF
--- a/src/components/IPForm.svelte
+++ b/src/components/IPForm.svelte
@@ -166,8 +166,8 @@
     .input-group {
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
+        gap: 0.25rem;
+        margin-bottom: 0.5rem;
     }
 
     .input-group label {
@@ -179,10 +179,10 @@
     }
 
     .input-group input {
-        padding: 0.75rem;
+        padding: 0.5rem 0.625rem;
         border: 1px solid var(--border-primary);
         border-radius: 0.375rem;
-        font-size: 0.875rem;
+        font-size: 0.8rem;
         transition: all 0.2s;
         background: var(--bg-primary);
         color: var(--text-primary);
@@ -225,8 +225,8 @@
         position: absolute;
         right: 1px;
         top: 1px;
-        width: 2rem;
-        height: calc(0.875rem * 1.5 + 0.75rem * 2);
+        width: 1.75rem;
+        height: calc(0.8rem * 1.5 + 0.5rem * 2);
         display: flex;
         flex-direction: column;
         border-radius: 0 0.3rem 0.3rem 0;
@@ -276,8 +276,8 @@
         background: var(--bg-secondary);
         border: 1px solid var(--border-secondary);
         border-radius: 0.375rem;
-        padding: 0.75rem;
-        margin-bottom: 1rem;
+        padding: 0.5rem 0.625rem;
+        margin-bottom: 0.5rem;
         font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
         font-size: 0.8rem;
         box-sizing: border-box;
@@ -383,12 +383,12 @@
     
     .action-btn {
         width: 100%;
-        padding: 0.75rem;
+        padding: 0.4rem 0.5rem;
         background: var(--accent-primary);
         color: white;
         border: none;
         border-radius: 0.375rem;
-        font-size: 0.875rem;
+        font-size: 0.8rem;
         font-weight: 500;
         cursor: pointer;
         transition: all 0.2s;

--- a/src/components/MapComponent.svelte
+++ b/src/components/MapComponent.svelte
@@ -7,6 +7,7 @@
     import { mapStyleStore, changeStyle } from '../store/state'
     import { dataStorage, updateDataStorage, resetZoneSpatialInfo } from '../store/data_storage'
     import { EMPTY_POLYGON_RGB } from '../lib/gl_draw_styles.js'
+    import { resolveMapStyle, EMPTY_MAP_STYLE, BLANK_MAP_STYLE_MARKER } from '../lib/map_styles'
     import { theme } from '../store/theme' // Add theme import
     import type { Feature, GeoJsonObject, Polygon } from 'geojson';
     
@@ -19,7 +20,7 @@
 
     const unsubStylesChange = accepted_uri.subscribe(value => {
         if (initialStylesURI !== value) {
-            $map.setStyle(value)
+            $map.setStyle(resolveMapStyle(value))
             initialStylesURI = $accepted_uri
         }
     })
@@ -43,10 +44,30 @@
         const initialState = { lng: 0, lat: 0, zoom: 5 };
         map.set(new MMap({
             container: mapContainer,
-            style: initialStylesURI,
+            style: resolveMapStyle(initialStylesURI),
             center: [initialState.lng, initialState.lat],
             zoom: initialState.zoom
         }));
+
+        let fellBackToBlank = false;
+        $map.on('error', (e: any) => {
+            if (fellBackToBlank) {
+                return
+            }
+            const err = e?.error;
+            const status = err?.status;
+            const isStyleLoadError = status === 401 || status === 403 || status === 404 ||
+                (typeof err?.message === 'string' && /style/i.test(err.message));
+            if (!isStyleLoadError) {
+                return
+            }
+            fellBackToBlank = true;
+            console.warn('Map style failed to load, falling back to blank style:', err);
+            $map.setStyle(EMPTY_MAP_STYLE);
+            mapStyleStore.accepted_uri.set(BLANK_MAP_STYLE_MARKER);
+            mapStyleStore.uri.set(BLANK_MAP_STYLE_MARKER);
+            initialStylesURI = BLANK_MAP_STYLE_MARKER;
+        })
 
         $map.on('load', () => {
             $map.resize()
@@ -260,9 +281,11 @@
         });
         if (hasValidCoords && isFinite(minLng) && isFinite(maxLng) && isFinite(minLat) && isFinite(maxLat)) {
             const bounds = new maplibregl.LngLatBounds([minLng, minLat], [maxLng, maxLat]);
+            const isBlank = $accepted_uri === BLANK_MAP_STYLE_MARKER;
             $map.fitBounds(bounds, {
                 maxZoom: 18,
-                padding: 100
+                padding: 100,
+                ...(isBlank ? { duration: 0 } : {})
             });
             return
         }

--- a/src/components/StylesForm.svelte
+++ b/src/components/StylesForm.svelte
@@ -1,16 +1,31 @@
 <script lang="ts">
-    import { mapStyleStore } from '../store/state'
+    import { mapStyleStore, DEFAULT_MAP_STYLE_URI } from '../store/state'
+    import { BLANK_MAP_STYLE_MARKER } from '$lib/map_styles'
     import { onMount } from 'svelte';
 
     const { uri } = mapStyleStore;
 
     let initialStylesURI = $uri
 
+    $: isBlank = $uri === BLANK_MAP_STYLE_MARKER
+    $: isApplied = $uri === initialStylesURI
+    $: isDefault = $uri === DEFAULT_MAP_STYLE_URI
+
     const changeStyles = () => {
         if (initialStylesURI !== $uri) {
             initialStylesURI = $uri
             mapStyleStore.accepted_uri.update(() => initialStylesURI);
         }
+    };
+
+    const useBlankMap = () => {
+        mapStyleStore.uri.set(BLANK_MAP_STYLE_MARKER);
+        initialStylesURI = BLANK_MAP_STYLE_MARKER;
+        mapStyleStore.accepted_uri.set(BLANK_MAP_STYLE_MARKER);
+    };
+
+    const resetUrl = () => {
+        mapStyleStore.uri.set(DEFAULT_MAP_STYLE_URI);
     };
 
     onMount(() => {
@@ -22,19 +37,35 @@
     <form autocomplete="off">
         <div class="input-group">
             <label for="input_style_url">Map Style URL</label>
-            <input 
-                bind:value={$uri} 
-                id="input_style_url" 
-                type="url" 
-                placeholder="https://api.maptiler.com/maps/..."
-            >
+            <div class="input-with-icon">
+                <input
+                    bind:value={$uri}
+                    id="input_style_url"
+                    type="url"
+                    placeholder="https://api.maptiler.com/maps/..."
+                >
+                {#if !isDefault}
+                    <button type="button" class="input-reset-btn" on:click={resetUrl} title="Reset to default URL">
+                        <i class="material-icons">restart_alt</i>
+                    </button>
+                {/if}
+            </div>
             <div class="input-hint">
-                MapTiler style JSON URL for map appearance
+                {#if isBlank}
+                    Blank map is active. Enter a URL and click Apply to switch back.
+                {:else}
+                    MapTiler style JSON URL for map appearance
+                {/if}
             </div>
         </div>
-        <button type="button" class="action-btn" on:click={changeStyles}>
-            Apply Style
-        </button>
+        <div class="button-row">
+            <button type="button" class="action-btn" on:click={changeStyles} disabled={isApplied || isBlank}>
+                Apply Style
+            </button>
+            <button type="button" class="action-btn secondary" on:click={useBlankMap} disabled={isBlank}>
+                Use blank map
+            </button>
+        </div>
     </form>
 </div>
 
@@ -46,8 +77,9 @@
     .input-group {
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
+        gap: 0.25rem;
+        margin-bottom: 0.5rem;
+        overflow: visible;
     }
 
     .input-group label {
@@ -58,11 +90,47 @@
         letter-spacing: 0.05em;
     }
 
+    .input-with-icon {
+        position: relative;
+        display: flex;
+        align-items: center;
+    }
+
+    .input-with-icon input {
+        padding-right: 2.25rem;
+    }
+
+    .input-reset-btn {
+        position: absolute;
+        right: 0.375rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.5rem;
+        height: 1.5rem;
+        padding: 0;
+        border: none;
+        border-radius: 0.25rem;
+        background: transparent;
+        color: var(--text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .input-reset-btn:hover {
+        background: var(--bg-tertiary, var(--bg-secondary));
+        color: var(--text-primary);
+    }
+
+    .input-reset-btn i {
+        font-size: 16px;
+    }
+
     .input-group input {
-        padding: 0.75rem;
+        padding: 0.5rem 0.625rem;
         border: 1px solid var(--border-primary);
         border-radius: 0.375rem;
-        font-size: 0.875rem;
+        font-size: 0.8rem;
         transition: all 0.2s;
         background: var(--bg-primary);
         color: var(--text-primary);
@@ -89,18 +157,33 @@
         opacity: 0.8;
     }
 
+    .button-row {
+        display: flex;
+        gap: 0.375rem;
+    }
+
     .action-btn {
-        width: 100%;
-        padding: 0.75rem;
+        flex: 1;
+        padding: 0.4rem 0.5rem;
         background: var(--success-primary);
         color: white;
         border: none;
         border-radius: 0.375rem;
-        font-size: 0.875rem;
+        font-size: 0.8rem;
         font-weight: 500;
         cursor: pointer;
         transition: background-color 0.2s;
         box-sizing: border-box;
+    }
+
+    .action-btn.secondary {
+        background: var(--bg-tertiary, var(--bg-secondary));
+        color: var(--text-primary);
+        border: 1px solid var(--border-primary);
+    }
+
+    .action-btn.secondary:hover {
+        background: var(--bg-secondary);
     }
 
     .action-btn:hover {

--- a/src/components/Switchers.svelte
+++ b/src/components/Switchers.svelte
@@ -2,10 +2,20 @@
   import IPForm from './IPForm.svelte'
   import StylesForm from './StylesForm.svelte'
   import { theme, toggleTheme } from '../store/theme'
+  import { apiUrlStore, mapStyleStore, DEFAULT_MAP_STYLE_URI, DEFAULT_API_SCHEMA, DEFAULT_API_HOST, DEFAULT_API_PORT } from '../store/state'
 
   export let klass: string = ''
-  
+
   let showSettings = false;
+
+  const resetAllSettings = () => {
+      theme.set('light');
+      apiUrlStore.schema.set(DEFAULT_API_SCHEMA);
+      apiUrlStore.host.set(DEFAULT_API_HOST);
+      apiUrlStore.port.set(DEFAULT_API_PORT);
+      mapStyleStore.uri.set(DEFAULT_MAP_STYLE_URI);
+      mapStyleStore.accepted_uri.set(DEFAULT_MAP_STYLE_URI);
+  };
 </script>
 
 <div class="switcher-container {klass}">
@@ -52,6 +62,13 @@
                         <StylesForm />
                     </div>
                 </div>
+
+                <div class="reset-section">
+                    <button type="button" class="reset-all-btn" on:click={resetAllSettings}>
+                        <i class="material-icons">settings_backup_restore</i>
+                        Reset to default
+                    </button>
+                </div>
             </div>
         </div>
     {/if}
@@ -77,15 +94,15 @@
   .theme-option {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      padding: 0.5rem 0.75rem;
+      gap: 0.375rem;
+      padding: 0.375rem 0.625rem;
       background: var(--bg-secondary);
       border: 1px solid var(--border-primary);
       border-radius: 0.375rem;
       cursor: pointer;
       transition: all 0.2s;
       color: var(--text-secondary);
-      font-size: 0.875rem;
+      font-size: 0.8rem;
   }
 
   .theme-option:hover {
@@ -145,38 +162,38 @@
       box-shadow: 0 4px 20px var(--shadow);
       animation: slideDown 0.3s ease;
       z-index: 1002;
-      width: 420px;
+      width: 380px;
       max-width: 90vw;
   }
-  
+
   .settings-content {
-      padding: 1.5rem;
-      display: flex;
-      flex-direction: column;
-      gap: 1.5rem;
-  }
-  
-  .form-section {
+      padding: 1rem;
       display: flex;
       flex-direction: column;
       gap: 0.75rem;
   }
-  
+
+  .form-section {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+  }
+
   .form-section h4 {
       margin: 0;
-      font-size: 0.875rem;
+      font-size: 0.75rem;
       font-weight: 600;
       color: var(--text-primary);
       text-transform: uppercase;
       letter-spacing: 0.05em;
-      padding-bottom: 0.5rem;
+      padding-bottom: 0.375rem;
       border-bottom: 1px solid var(--border-secondary);
   }
   
   .form-wrapper {
     width: calc(100% - 0rem); /* Slight adjustment to prevent overflow */
     max-width: 100%;
-    overflow: hidden;
+    overflow: visible;
   }
   
   :global(.settings-panel .api-form),
@@ -193,6 +210,36 @@
       max-width: 100%;
   }
   
+  .reset-section {
+      padding-top: 0.5rem;
+      border-top: 1px solid var(--border-secondary);
+  }
+
+  .reset-all-btn {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      width: 100%;
+      padding: 0.4rem 0.625rem;
+      background: transparent;
+      border: 1px solid var(--border-primary);
+      border-radius: 0.375rem;
+      color: var(--text-secondary);
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: all 0.2s;
+  }
+
+  .reset-all-btn:hover {
+      background: var(--bg-secondary);
+      color: var(--text-primary);
+      border-color: var(--border-secondary);
+  }
+
+  .reset-all-btn i {
+      font-size: 18px;
+  }
+
   @keyframes slideDown {
       from {
           opacity: 0;

--- a/src/lib/map_styles.ts
+++ b/src/lib/map_styles.ts
@@ -1,0 +1,17 @@
+import type { StyleSpecification } from 'maplibre-gl';
+
+export const BLANK_MAP_STYLE_MARKER = 'blank';
+
+export const EMPTY_MAP_STYLE: StyleSpecification = {
+    version: 8,
+    sources: {},
+    layers: [{
+        id: 'background',
+        type: 'background',
+        paint: { 'background-color': '#e5e5e5' }
+    }]
+};
+
+export function resolveMapStyle(value: string): string | StyleSpecification {
+    return value === BLANK_MAP_STYLE_MARKER ? EMPTY_MAP_STYLE : value;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -69,6 +69,23 @@
             }
         })
         const endpoint = `${initialAPIURL}/api/polygons/geojson`
+
+        // Two async operations race: map style load and data fetch.
+        // With fast styles (e.g. blank), 'load' fires before fetch completes.
+        // Coordinate via two flags so drawGeoPolygons runs once both are done.
+        let mapReady = (subType === SubscriberState.ReInit) || $map.isStyleLoaded()
+        let dataFetched = false
+
+        const tryDrawGeo = () => {
+            if (mapReady && dataFetched) {
+                mapComponent.drawGeoPolygons($draw, $dataStorage)
+            }
+        }
+
+        if (!mapReady) {
+            $map.once('load', () => { mapReady = true; tryDrawGeo() })
+        }
+
         fetch(`${endpoint}`)
             .then((response) => {
                 return response.json()
@@ -77,13 +94,8 @@
                 data.features.forEach((feature: ZoneFeature) => {
                     addZoneFeature(feature)
                 });
-                if (subType === SubscriberState.ReInit) {
-                    mapComponent.drawGeoPolygons($draw, $dataStorage);
-                } else {
-                    $map.on('load', () => {
-                        mapComponent.drawGeoPolygons($draw, $dataStorage);
-                    });
-                }
+                dataFetched = true
+                tryDrawGeo()
                 dataReady.set(true)
             })
             .catch((error) => {
@@ -99,8 +111,8 @@
             /* Clean UP */
             canvasReady.set(false)
             dataReady.set(false)
-            unsubscribeCanvas()
-            unsubscribeGeoData()
+            if (unsubscribeCanvas) unsubscribeCanvas()
+            if (unsubscribeGeoData) unsubscribeGeoData()
             clearDataStorage()
             if ($canvasState !== undefined && $canvasState != null) {
                 //@ts-ignore

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -1,7 +1,6 @@
 import { States } from '$lib/states';
-import { derived, writable, type Writable } from 'svelte/store'
+import { derived, get, writable, type Writable } from 'svelte/store'
 import type { FabricCanvasWrap } from '$lib/custom_canvas';
-// import { apiURL } from '../store/polygons'
 
 export const canvasState: Writable<FabricCanvasWrap | undefined> = writable()
 export const state = writable(States.Waiting);
@@ -9,21 +8,38 @@ export const state = writable(States.Waiting);
 export const canvasReady = writable(false)
 export const dataReady = writable(false)
 
+function persisted<T>(key: string, fallback: T): Writable<T> {
+    let initial = fallback;
+    try {
+        const raw = localStorage.getItem(key);
+        if (raw !== null) {
+            initial = typeof fallback === 'number' ? Number(raw) as unknown as T : raw as unknown as T;
+        }
+    } catch {
+        // SSR or private browsing
+    }
+    const store = writable<T>(initial);
+    store.subscribe(value => {
+        try { localStorage.setItem(key, String(value)); } catch { /* ignore */ }
+    });
+    return store;
+}
+
 const defaultSchema = 'http'
 const defaultHost = 'localhost'
 const defaultPort = 42001
 
 const currentURL = window.location.href
 const appURL = new URL(currentURL)
-const appSchema = appURL.protocol.replace(/:/g,'') || defaultSchema
-const appHost = appURL.hostname || defaultHost
-const appPort = process.env.NODE_ENV === 'development'? defaultPort : parseInt(appURL.port) || ((appSchema === 'https:') ? 443 : 80) || defaultPort
+export const DEFAULT_API_SCHEMA = appURL.protocol.replace(/:/g,'') || defaultSchema
+export const DEFAULT_API_HOST = appURL.hostname || defaultHost
+export const DEFAULT_API_PORT = process.env.NODE_ENV === 'development'? defaultPort : parseInt(appURL.port) || ((DEFAULT_API_SCHEMA === 'https') ? 443 : 80) || defaultPort
 
 class ApiSchema {
     constructor(
-        public schema: Writable<string> = writable(appSchema),
-        public host: Writable<string> = writable(appHost),
-        public port: Writable<number> = writable(appPort)
+        public schema: Writable<string> = persisted('settings:api_schema', DEFAULT_API_SCHEMA),
+        public host: Writable<string> = persisted('settings:api_host', DEFAULT_API_HOST),
+        public port: Writable<number> = persisted('settings:api_port', DEFAULT_API_PORT)
     ) {}
 
     get apiURL() {
@@ -38,18 +54,20 @@ class ApiSchema {
 
 // Singleton
 export const apiUrlStore = new ApiSchema();
-export const changeAPI = writable(`${appSchema}://${appHost}:${appPort}`)
+
+// Initialize changeAPI from persisted values (not hardcoded defaults)
+const persistedApiURL = get(apiUrlStore.apiURL)
+export const changeAPI = writable(persistedApiURL)
+
+export const DEFAULT_MAP_STYLE_URI = 'https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL';
 
 class MapStyle {
     constructor(
-        public uri: Writable<string> = writable('https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL'),
-        public accepted_uri: Writable<string> = writable('https://api.maptiler.com/maps/streets/style.json?key=get_your_own_OpIi9ZULNHzrESv6T2vL')
+        public uri: Writable<string> = persisted('settings:map_style_uri', DEFAULT_MAP_STYLE_URI),
+        public accepted_uri: Writable<string> = persisted('settings:map_style_accepted_uri', DEFAULT_MAP_STYLE_URI)
     ) {}
 }
 
 export const mapStyleStore = new MapStyle();
 
 export const changeStyle = writable(mapStyleStore.accepted_uri)
-
-// Allow for multiple stores (good for contexts)
-// export const apiUrlStore = () => new ApiSchema();


### PR DESCRIPTION
When deploying the system, users often lack a valid API key for loading map tiles (MapTiler, etc.). In such cases the map failed to load entirely - the user was left with a blank screen and no way to work with zones and polygons. This blocked the initial configuration workflow.

I've decided to give an automatic fallback. If the map style fails to load (invalid key, unreachable server, 401/403/404), the system automatically switches to a blank map with a neutral gray background. The user can immediately start working with zones - geocoordinate bindings remain fully functional.

And then I've come with idea to switch to blank map manually: A "Use blank map" button has been added to the Settings panel. This is useful for:
- engineers who work exclusively with coordinates and don't need a visual basemap;
- low-bandwidth environments where tile loading slows down the workflow;
- scenarios where the basemap distracts from zone geometry.

And the second major change in this PR is settings persistence across sessions. I.e. all user settings are now stored in browser localStorage:
- map style URL (including the "blank map" choice);
- API server connection parameters (protocol, host, port);
- UI theme (light / dark).
So after a page reload the system restores the last known state.

And then I've come up with decision to have settings reset button, so users could reset it to default in case they've messed up.