### PR TITLE
Allow to change coordinates manually

### DIFF
--- a/src/components/CompleteZoneForm.svelte
+++ b/src/components/CompleteZoneForm.svelte
@@ -1,0 +1,276 @@
+<script lang="ts">
+    import { createEventDispatcher } from 'svelte';
+    import type { Zone } from '$lib/zones';
+
+    export let zone: Zone;
+
+    const dispatch = createEventDispatcher<{
+        save: {
+            coordinates: number[][][],
+            road_lane_direction: number,
+            road_lane_num: number,
+        },
+        highlight: { pointIndex: number | null },
+    }>();
+
+    const labels = ['A', 'B', 'C', 'D'] as const;
+
+    function getPoint(idx: number): { lng: string; lat: string } {
+        const ring = zone.geometry?.coordinates?.[0];
+        if (ring && ring[idx] && isFinite(ring[idx][0]) && isFinite(ring[idx][1])) {
+            return { lng: String(ring[idx][0]), lat: String(ring[idx][1]) };
+        }
+        return { lng: '', lat: '' };
+    }
+
+    let points = [0, 1, 2, 3].map(i => getPoint(i));
+    let laneDirection = zone.properties.road_lane_direction ?? -1;
+    let laneNum = zone.properties.road_lane_num ?? -1;
+
+    $: allFilled = points.every(p => p.lng !== '' && p.lat !== '');
+    $: hasChanges = (() => {
+        const ring = zone.geometry?.coordinates?.[0];
+        for (let i = 0; i < 4; i++) {
+            const lng = parseFloat(points[i].lng);
+            const lat = parseFloat(points[i].lat);
+            if (!ring || !ring[i] || ring[i][0] !== lng || ring[i][1] !== lat) return true;
+        }
+        if (laneDirection !== zone.properties.road_lane_direction) return true;
+        if (laneNum !== zone.properties.road_lane_num) return true;
+        return false;
+    })();
+
+    function handleSave() {
+        const coords = points.map(p => [parseFloat(p.lng), parseFloat(p.lat)]);
+        coords.push([...coords[0]]);
+        dispatch('save', {
+            coordinates: [coords],
+            road_lane_direction: laneDirection,
+            road_lane_num: laneNum,
+        });
+    }
+</script>
+
+<div class="zone-form">
+    <div class="coords-section">
+        <span class="section-label">Polygon vertices (WGS84)</span>
+        <div class="coords-header">
+            <span class="header-spacer"></span>
+            <span class="header-label">Longitude</span>
+            <span class="header-label">Latitude</span>
+        </div>
+        <div class="coords-grid">
+            {#each labels as label, i}
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <div
+                    class="coord-row"
+                    on:mouseenter={() => dispatch('highlight', { pointIndex: i })}
+                    on:mouseleave={() => dispatch('highlight', { pointIndex: null })}
+                >
+                    <span class="point-label">{label}</span>
+                    <input
+                        type="number"
+                        step="any"
+                        placeholder="0.000000"
+                        bind:value={points[i].lng}
+                    >
+                    <input
+                        type="number"
+                        step="any"
+                        placeholder="0.000000"
+                        bind:value={points[i].lat}
+                    >
+                </div>
+            {/each}
+        </div>
+    </div>
+
+    <div class="divider"></div>
+
+    <div class="lane-section">
+        <span class="section-label">Lane parameters</span>
+        <div class="lane-row">
+            <div class="lane-field">
+                <label for="lane-dir-{zone.id}">Direction</label>
+                <input id="lane-dir-{zone.id}" type="number" bind:value={laneDirection}>
+            </div>
+            <div class="lane-field">
+                <label for="lane-num-{zone.id}">Lane number</label>
+                <input id="lane-num-{zone.id}" type="number" bind:value={laneNum}>
+            </div>
+        </div>
+    </div>
+
+    <button
+        type="button"
+        class="save-btn"
+        disabled={!allFilled || !hasChanges}
+        on:click={handleSave}
+    >
+        Save changes
+    </button>
+</div>
+
+<style>
+    .zone-form {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .section-label {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-secondary);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .divider {
+        height: 1px;
+        background: var(--border-secondary);
+    }
+
+    /* Coordinates */
+    .coords-section {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .coords-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .header-spacer {
+        width: 28px;
+        flex-shrink: 0;
+    }
+
+    .header-label {
+        flex: 1;
+        font-size: 11px;
+        color: var(--text-secondary);
+        font-weight: 500;
+    }
+
+    .coords-grid {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .coord-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px;
+        border-radius: 6px;
+        transition: background-color 0.15s;
+    }
+
+    .coord-row:hover {
+        background: var(--bg-secondary);
+    }
+
+    .point-label {
+        width: 24px;
+        height: 24px;
+        line-height: 24px;
+        font-size: 12px;
+        font-weight: 700;
+        border-radius: 4px;
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+        text-align: center;
+        flex-shrink: 0;
+    }
+
+    .coord-row:hover .point-label {
+        background: var(--accent-primary);
+        color: white;
+    }
+
+    .coords-grid input,
+    .lane-field input {
+        flex: 1;
+        min-width: 0;
+        padding: 8px 10px;
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        font-size: 13px;
+        font-family: monospace;
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        box-sizing: border-box;
+        transition: border-color 0.15s, box-shadow 0.15s;
+    }
+
+    .coords-grid input:focus,
+    .lane-field input:focus {
+        outline: none;
+        border-color: var(--accent-primary);
+        box-shadow: 0 0 0 2px rgba(var(--accent-primary-rgb), 0.15);
+    }
+
+    /* Hide number spinners */
+    input[type="number"]::-webkit-inner-spin-button,
+    input[type="number"]::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+    input[type="number"] {
+        -moz-appearance: textfield;
+        appearance: textfield;
+    }
+
+    /* Lane parameters */
+    .lane-section {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .lane-row {
+        display: flex;
+        gap: 12px;
+    }
+
+    .lane-field {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .lane-field label {
+        font-size: 11px;
+        font-weight: 500;
+        color: var(--text-secondary);
+    }
+
+    /* Save button */
+    .save-btn {
+        width: 100%;
+        padding: 10px 16px;
+        background: var(--success-primary);
+        color: white;
+        border: none;
+        border-radius: 6px;
+        font-size: 14px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background-color 0.2s;
+    }
+
+    .save-btn:hover:not(:disabled) {
+        background: var(--success-hover);
+    }
+
+    .save-btn:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+</style>

--- a/src/components/ConfigurationStorage.svelte
+++ b/src/components/ConfigurationStorage.svelte
@@ -1,18 +1,105 @@
 <script lang="ts">
     import { type Writable } from 'svelte/store'
     import { DirectionType, type Zone } from '$lib/zones';
+    import { map, draw } from '../store/map';
+    import { updateDataStorage } from '../store/data_storage';
+    import { EMPTY_POLYGON_RGB } from '../lib/gl_draw_styles.js';
+    import CompleteZoneForm from './CompleteZoneForm.svelte';
+    import maplibregl from 'maplibre-gl';
 
     export let klass: string = ''
     export let dataReady: Writable<boolean>
     export let data: [string, Zone][]
 
     let expandedZones: { [key: string]: boolean } = {};
+    let modalZone: Zone | null = null;
+    let highlightMarkers: maplibregl.Marker[] = [];
 
     const toggleZone = (key: string) => {
         expandedZones[key] = !expandedZones[key];
         expandedZones = expandedZones;
     };
+
+    function openEditModal(zone: Zone) {
+        modalZone = zone;
+    }
+
+    function closeModal() {
+        highlightMarkers.forEach(m => m.remove());
+        highlightMarkers = [];
+        modalZone = null;
+    }
+
+    function handleHighlight(zone: Zone, e: CustomEvent<{ pointIndex: number | null }>) {
+        highlightMarkers.forEach(m => m.remove());
+        highlightMarkers = [];
+
+        const idx = e.detail.pointIndex;
+        if (idx === null || !$map) return;
+
+        const ring = zone.geometry?.coordinates?.[0];
+        if (!ring || !ring[idx]) return;
+
+        const [lng, lat] = ring[idx];
+        if (!isFinite(lng) || !isFinite(lat)) return;
+
+        const el = document.createElement('div');
+        el.style.cssText = `
+            width: 14px; height: 14px;
+            border-radius: 50%;
+            border: 2px solid ${zone.properties.color_rgb_str || '#ff0000'};
+            background: rgba(255,255,255,0.8);
+            pointer-events: none;
+        `;
+
+        const marker = new maplibregl.Marker({ element: el })
+            .setLngLat([lng, lat])
+            .addTo($map);
+        highlightMarkers = [marker];
+    }
+
+    function handleSave(zone: Zone, e: CustomEvent<{ coordinates: number[][][], road_lane_direction: number, road_lane_num: number }>) {
+        const { coordinates, road_lane_direction, road_lane_num } = e.detail;
+
+        zone.properties.road_lane_direction = road_lane_direction;
+        zone.properties.road_lane_num = road_lane_num;
+        zone.geometry.coordinates = coordinates;
+
+        const spatialId = zone.properties.spatial_object_id || `spatial-${zone.id}`;
+        zone.properties.spatial_object_id = spatialId;
+
+        const geoFeature = {
+            type: 'Feature' as const,
+            id: spatialId,
+            properties: {
+                color_rgb_str: zone.properties.color_rgb_str || EMPTY_POLYGON_RGB,
+            },
+            geometry: {
+                type: 'Polygon' as const,
+                coordinates: coordinates,
+            }
+        };
+
+        $draw.add(geoFeature);
+        $draw.setFeatureProperty(spatialId, 'color_rgb_str', zone.properties.color_rgb_str || EMPTY_POLYGON_RGB);
+        updateDataStorage(zone.id, zone);
+        closeModal();
+    }
+
+    function handleBackdropClick(e: MouseEvent) {
+        if ((e.target as HTMLElement).classList.contains('modal-backdrop')) {
+            closeModal();
+        }
+    }
+
+    function handleKeydown(e: KeyboardEvent) {
+        if (e.key === 'Escape' && modalZone) {
+            closeModal();
+        }
+    }
 </script>
+
+<svelte:window on:keydown={handleKeydown} />
 
 <div id="configuration" class={klass}>
     <div id="configuration-content">
@@ -35,7 +122,6 @@
                         </div>
                         <span class="expand-arrow">{expandedZones[k] ? '▼' : '▶'}</span>
                     </button>
-                    
                     {#if expandedZones[k]}
                         <div class="zone-content">
                             <table class="table table-sm">
@@ -50,7 +136,7 @@
                                     </tr>
                                     <tr>
                                         <td>Spatial object ID</td>
-                                        <td>{element.properties.spatial_object_id}</td>
+                                        <td>{element.properties.spatial_object_id ?? '-'}</td>
                                     </tr>
                                     <tr>
                                         <td>Color</td>
@@ -81,6 +167,10 @@
                                     {/if}
                                 </tbody>
                             </table>
+                            <button class="edit-btn" on:click={() => openEditModal(element)}>
+                                <i class="material-icons">edit</i>
+                                Edit
+                            </button>
                         </div>
                     {/if}
                 </div>
@@ -88,6 +178,30 @@
         {/if}
     </div>
 </div>
+
+{#if modalZone}
+    <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+    <div class="modal-backdrop" on:click={handleBackdropClick}>
+        <div class="modal-panel">
+            <div class="modal-header">
+                <div class="modal-title-row">
+                    <div class="color-swatch modal-swatch" style="background-color: {modalZone.properties.color_rgb_str};"></div>
+                    <h3>Zone {modalZone.id}</h3>
+                </div>
+                <button class="modal-close" on:click={closeModal}>
+                    <i class="material-icons">close</i>
+                </button>
+            </div>
+            <div class="modal-body">
+                <CompleteZoneForm
+                    zone={modalZone}
+                    on:save={(e) => handleSave(modalZone!, e)}
+                    on:highlight={(e) => handleHighlight(modalZone!, e)}
+                />
+            </div>
+        </div>
+    </div>
+{/if}
 
 <style scoped>
     #configuration {
@@ -104,17 +218,17 @@
         background-color: var(--bg-primary);
         width: 8px;
     }
-    
+
     #configuration::-webkit-scrollbar-track {
         background-color: var(--bg-secondary);
     }
-    
+
     #configuration::-webkit-scrollbar-thumb {
         background-color: var(--text-secondary);
         border-radius: 4px;
         opacity: 0.7;
     }
-    
+
     #configuration::-webkit-scrollbar-thumb:hover {
         background-color: var(--text-primary);
         opacity: 0.9;
@@ -234,5 +348,106 @@
         font-family: monospace;
         color: var(--text-primary);
         word-break: break-all;
+    }
+
+    .edit-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        margin-top: 8px;
+        padding: 4px 10px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-primary);
+        border-radius: 3px;
+        color: var(--text-secondary);
+        font-size: 11px;
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .edit-btn:hover {
+        color: var(--accent-primary);
+        border-color: var(--accent-primary);
+    }
+
+    .edit-btn i {
+        font-size: 14px;
+    }
+
+    /* Modal */
+    .modal-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 2000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .modal-panel {
+        background: var(--bg-primary);
+        border: 1px solid var(--border-primary);
+        border-radius: 8px;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+        width: 420px;
+        max-width: 90vw;
+        max-height: 80vh;
+        overflow-y: auto;
+    }
+
+    .modal-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 20px;
+        border-bottom: 1px solid var(--border-secondary);
+    }
+
+    .modal-title-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .modal-title-row h3 {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .modal-swatch {
+        width: 20px;
+        height: 20px;
+        border-radius: 4px;
+    }
+
+    .modal-close {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        color: var(--text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .modal-close:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+    }
+
+    .modal-close i {
+        font-size: 18px;
+    }
+
+    .modal-body {
+        padding: 16px 20px 20px;
     }
 </style>

--- a/src/components/ConfigurationStorage.svelte
+++ b/src/components/ConfigurationStorage.svelte
@@ -28,6 +28,9 @@
                                 </g>
                             </svg>
                             <span class="zone-title">Zone {element.id}</span>
+                            {#if !element.properties.spatial_object_id}
+                                <span class="zone-badge not-linked">Not linked</span>
+                            {/if}
                             <span class="zone-status">{element.properties.virtual_line ? '• Has virtual line' : '• No virtual line'}</span>
                         </div>
                         <span class="expand-arrow">{expandedZones[k] ? '▼' : '▶'}</span>
@@ -156,6 +159,22 @@
     .zone-title {
         font-weight: 600;
         color: var(--text-primary);
+    }
+
+    .zone-badge {
+        font-size: 10px;
+        font-weight: 600;
+        padding: 1px 6px;
+        border-radius: 3px;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        flex-shrink: 0;
+    }
+
+    .zone-badge.not-linked {
+        background: var(--warning-bg, #fef3c7);
+        color: var(--warning-text, #92400e);
+        border: 1px solid var(--warning-border, #fcd34d);
     }
 
     .zone-status {

--- a/src/components/MapComponent.svelte
+++ b/src/components/MapComponent.svelte
@@ -615,13 +615,12 @@
     .coords-side-panel {
         width: 0;
         overflow: hidden;
-        background: var(--bg-primary);
+        background: #1a1a1a;
         border-top: 1px solid var(--border-primary);
         border-right: 1px solid var(--border-primary);
         border-bottom: 1px solid var(--border-primary);
         border-left: none;
         border-radius: 0 12px 12px 0;
-        box-shadow: 4px 4px 20px var(--shadow);
         flex-shrink: 0;
         transition: width 0.3s ease;
     }
@@ -703,33 +702,36 @@
         color: white;
     }
 
-    .coords-input {
+    .coords-side-panel input.coords-input {
         flex: 1;
         min-width: 0;
-        padding: 5px 7px;
-        border: 1px solid var(--border-primary);
-        border-radius: 4px;
-        font-size: 11px;
-        font-family: monospace;
-        background: var(--bg-primary);
-        color: var(--text-primary);
+        padding: 4px 6px !important;
+        border: 1px solid var(--border-primary) !important;
+        border-radius: 4px !important;
+        font-size: 11px !important;
+        line-height: 1.3 !important;
+        font-family: monospace !important;
+        background: var(--bg-primary) !important;
+        color: var(--text-primary) !important;
         box-sizing: border-box;
+        height: auto !important;
+        min-height: 0 !important;
         transition: border-color 0.15s, box-shadow 0.15s;
     }
 
-    .coords-input:focus {
-        outline: none;
-        border-color: var(--accent-primary);
-        box-shadow: 0 0 0 2px rgba(var(--accent-primary-rgb), 0.15);
+    .coords-side-panel input.coords-input:focus {
+        outline: none !important;
+        border-color: var(--accent-primary) !important;
+        box-shadow: 0 0 0 2px rgba(var(--accent-primary-rgb), 0.15) !important;
     }
 
     /* Hide number spinners in popup */
-    .coords-input::-webkit-inner-spin-button,
-    .coords-input::-webkit-outer-spin-button {
+    .coords-side-panel input.coords-input::-webkit-inner-spin-button,
+    .coords-side-panel input.coords-input::-webkit-outer-spin-button {
         -webkit-appearance: none;
         margin: 0;
     }
-    .coords-input {
+    .coords-side-panel input.coords-input {
         -moz-appearance: textfield;
         appearance: textfield;
     }

--- a/src/components/MapComponent.svelte
+++ b/src/components/MapComponent.svelte
@@ -263,7 +263,7 @@
             Array.from($dataStorage.values()).some(element => {
                 if (element.properties.spatial_object_id === mapFeature.id) {
                     const value = element.id ?? 'No canvas ID';
-                    const color = element.properties.color_rgb_str;
+                    const color = element.properties.color_rgb_str ?? '#666';
                     hiddenInput.value = value;
                     selectedColor.style.backgroundColor = color;
                     selectedColor.style.display = 'block';

--- a/src/components/MapComponent.svelte
+++ b/src/components/MapComponent.svelte
@@ -90,62 +90,85 @@
             });
             
             const clickedFeature = [...$dataStorage].find((f) => f[1].properties.spatial_object_id === mapFeature.id)?.[1]
-            
+
+            // Get current polygon vertex coordinates
+            const polyGeom = mapFeature.geometry as Polygon;
+            const ring = polyGeom?.coordinates?.[0] || [];
+            const vertexLabels = ['A', 'B', 'C', 'D'];
+            const vertices = vertexLabels.map((label, i) => {
+                const coord = ring[i];
+                return {
+                    label,
+                    lng: coord && isFinite(coord[0]) ? coord[0] : '',
+                    lat: coord && isFinite(coord[1]) ? coord[1] : '',
+                };
+            });
+
             const popupContent = `
                 <div class="popup-container" data-theme="${$theme}">
-                    <div class="popup-header">
-                        <h3 class="popup-title">Zone Configuration</h3>
-                    </div>
-                    
-                    <div class="popup-content">
-                        <div class="form-control w-full">
-                            <label class="label">
-                                <span class="label-text">Attach canvas polygons</span>
-                            </label>
-                            <div class="custom-select-wrapper">
-                                <div class="custom-select-trigger" id="select-trigger">
-                                    <div class="selected-option">
-                                        <div class="selected-color" id="selected-color" style="display: none;"></div>
-                                        <span class="selected-text" id="selected-text">Pick up polygon</span>
-                                    </div>
-                                    <i class="material-icons dropdown-arrow">expand_more</i>
-                                </div>
-                                <div class="custom-select-dropdown" id="select-dropdown">
-                                    ${polygonOptions.map(option => `
-                                        <div class="custom-option" data-value="${option.id}" data-color="${option.color}">
-                                            <div class="option-color" style="background-color: ${option.color};"></div>
-                                            <span class="option-text">${option.label}</span>
+                    <div class="popup-main" id="popup-main">
+                        <div class="popup-header">
+                            <h3 class="popup-title">Zone Configuration</h3>
+                            <button class="popup-close-btn" id="popup-close-btn" type="button">
+                                <i class="material-icons">close</i>
+                            </button>
+                        </div>
+
+                        <div class="popup-content">
+                            <div class="form-control w-full">
+                                <label class="label">
+                                    <span class="label-text">Attach canvas polygons</span>
+                                </label>
+                                <div class="custom-select-wrapper">
+                                    <div class="custom-select-trigger" id="select-trigger">
+                                        <div class="selected-option">
+                                            <div class="selected-color" id="selected-color" style="display: none;"></div>
+                                            <span class="selected-text" id="selected-text">Pick up polygon</span>
                                         </div>
-                                    `).join('')}
+                                        <i class="material-icons dropdown-arrow">expand_more</i>
+                                    </div>
+                                    <div class="custom-select-dropdown" id="select-dropdown">
+                                        ${polygonOptions.map(option => `
+                                            <div class="custom-option" data-value="${option.id}" data-color="${option.color}">
+                                                <div class="option-color" style="background-color: ${option.color};"></div>
+                                                <span class="option-text">${option.label}</span>
+                                            </div>
+                                        `).join('')}
+                                    </div>
+                                    <input type="hidden" id="select-canvas" value="">
                                 </div>
-                                <input type="hidden" id="select-canvas" value="">
                             </div>
+
+                            <div class="form-control w-full">
+                                <label class="label">
+                                    <span class="label-text">Direction value</span>
+                                </label>
+                                <input
+                                    value="${clickedFeature ? clickedFeature.properties?.road_lane_direction : -1}"
+                                    id="lane-direction"
+                                    type="number"
+                                    class="input input-bordered w-full"
+                                >
+                            </div>
+
+                            <div class="form-control w-full">
+                                <label class="label">
+                                    <span class="label-text">Lane</span>
+                                </label>
+                                <input
+                                    value="${clickedFeature ? clickedFeature.properties?.road_lane_num : -1}"
+                                    id="lane-number"
+                                    type="number"
+                                    class="input input-bordered w-full"
+                                >
+                            </div>
+
+                            <button id="toggle-coords-btn" class="toggle-coords-btn" type="button">
+                                <i class="material-icons" id="toggle-coords-icon">chevron_right</i>
+                                Edit coordinates
+                            </button>
                         </div>
-                        
-                        <div class="form-control w-full">
-                            <label class="label">
-                                <span class="label-text">Direction value</span>
-                            </label>
-                            <input 
-                                value="${clickedFeature ? clickedFeature.properties?.road_lane_direction : -1}" 
-                                id="lane-direction" 
-                                type="number" 
-                                class="input input-bordered w-full"
-                            >
-                        </div>
-                        
-                        <div class="form-control w-full">
-                            <label class="label">
-                                <span class="label-text">Lane</span>
-                            </label>
-                            <input 
-                                value="${clickedFeature ? clickedFeature.properties?.road_lane_num : -1}" 
-                                id="lane-number" 
-                                type="number" 
-                                class="input input-bordered w-full"
-                            >
-                        </div>
-                        
+
                         <div class="form-actions">
                             <button id="attach-canvas-btn" class="btn btn-primary btn-sm">
                                 <i class="material-icons">save</i>
@@ -153,18 +176,48 @@
                             </button>
                         </div>
                     </div>
+
+                    <div class="coords-side-panel" id="coords-slide">
+                        <div class="coords-side-header">
+                            <span class="coords-side-title">Coordinates</span>
+                        </div>
+                        <div class="coords-side-body">
+                            <div class="coords-col-headers">
+                                <span class="coords-spacer"></span>
+                                <span class="coords-col-label">Longitude</span>
+                                <span class="coords-col-label">Latitude</span>
+                            </div>
+                            ${vertices.map((v, i) => `
+                                <div class="coords-row">
+                                    <span class="coords-point-label">${v.label}</span>
+                                    <input type="number" step="any" placeholder="0.000000" value="${v.lng}" id="coord-lng-${i}" class="coords-input">
+                                    <input type="number" step="any" placeholder="0.000000" value="${v.lat}" id="coord-lat-${i}" class="coords-input">
+                                </div>
+                            `).join('')}
+                            <button id="save-coords-btn" class="save-coords-btn" type="button">
+                                Save coordinates
+                            </button>
+                        </div>
+                    </div>
                 </div>
             `
             
-            new maplibregl.Popup({ 
+            const popup = new maplibregl.Popup({
                 className: "themed-popup",
-                closeButton: true,
-                closeOnClick: false
+                closeButton: false,
+                closeOnClick: false,
+                maxWidth: 'none'
             })
                 .setLngLat(e.lngLat)
                 .setHTML(popupContent)
                 .addTo($map);
                 
+            // Close button
+            const popupCloseBtn = document.getElementById('popup-close-btn');
+            if (popupCloseBtn) {
+                popupCloseBtn.addEventListener('click', () => popup.remove());
+            }
+
             // Setup custom dropdown functionality
             const selectTrigger = document.getElementById("select-trigger");
             const selectDropdown = document.getElementById("select-dropdown");
@@ -219,6 +272,49 @@
                 }
             });
             
+            // Toggle coordinates slide
+            const toggleBtn = document.getElementById('toggle-coords-btn');
+            const coordsSlide = document.getElementById('coords-slide');
+            const toggleIcon = document.getElementById('toggle-coords-icon');
+            const popupMain = document.getElementById('popup-main');
+            if (toggleBtn && coordsSlide && toggleIcon && popupMain) {
+                toggleBtn.addEventListener('click', () => {
+                    const isOpen = coordsSlide.classList.toggle('open');
+                    toggleIcon.textContent = isOpen ? 'chevron_left' : 'chevron_right';
+                    popupMain.classList.toggle('side-open', isOpen);
+                });
+            }
+
+            // Save coordinates
+            const saveCoordsBtn = document.getElementById('save-coords-btn');
+            if (saveCoordsBtn) {
+                saveCoordsBtn.addEventListener('click', () => {
+                    const coords: number[][] = [];
+                    for (let i = 0; i < 4; i++) {
+                        const lngEl = <HTMLInputElement>document.getElementById(`coord-lng-${i}`);
+                        const latEl = <HTMLInputElement>document.getElementById(`coord-lat-${i}`);
+                        if (!lngEl || !latEl) return;
+                        const lng = parseFloat(lngEl.value);
+                        const lat = parseFloat(latEl.value);
+                        if (!isFinite(lng) || !isFinite(lat)) return;
+                        coords.push([lng, lat]);
+                    }
+                    coords.push([...coords[0]]); // close ring
+                    // Update draw feature geometry
+                    const updated = $draw.get(mapFeature.id as string);
+                    if (updated && updated.geometry.type === 'Polygon') {
+                        updated.geometry.coordinates = [coords];
+                        $draw.add(updated);
+                    }
+                    // Update dataStorage if linked
+                    const linked = [...$dataStorage].find((f) => f[1].properties.spatial_object_id === mapFeature.id)?.[1];
+                    if (linked) {
+                        linked.geometry.coordinates = [coords];
+                        updateDataStorage(linked.id, linked);
+                    }
+                });
+            }
+
             const attachBtn = document.getElementById('attach-canvas-btn');
             if (!attachBtn) {
                 console.error("No container 'attach-canvas-btn'")
@@ -228,7 +324,7 @@
                 const directionElem = <HTMLInputElement>document.getElementById("lane-direction");
                 const laneElem = <HTMLInputElement>document.getElementById("lane-number");
                 attachSpatialToDataStorage(mapFeature, hiddenInput.value, {
-                    road_lane_direction: directionElem ? parseInt(directionElem.value) : -1, 
+                    road_lane_direction: directionElem ? parseInt(directionElem.value) : -1,
                     road_lane_num: laneElem ? parseInt(laneElem.value) : -1
                 });
             });
@@ -350,14 +446,12 @@
 
     /* DaisyUI themed popup styling */
     .maplibregl-popup.themed-popup .maplibregl-popup-content {
-        background: var(--bg-primary);
-        border: 1px solid var(--border-primary);
-        border-radius: 12px;
-        box-shadow: 0 4px 20px var(--shadow);
+        background: transparent;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
         padding: 0;
-        min-width: 320px;
-        max-width: 380px;
-        transition: background-color 0.3s ease, border-color 0.3s ease;
+        overflow: visible;
     }
 
     .maplibregl-popup.themed-popup .maplibregl-popup-tip {
@@ -369,45 +463,77 @@
     }
 
     .maplibregl-popup.themed-popup .maplibregl-popup-close-button {
-        background: var(--bg-secondary);
-        color: var(--text-secondary);
-        border: 1px solid var(--border-primary);
-        border-radius: 6px;
-        width: 28px;
-        height: 28px;
-        top: 12px;
-        right: 12px;
-        font-size: 18px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: all 0.2s;
-        transition: all 0.3s ease;
+        display: none;
     }
 
-    .maplibregl-popup.themed-popup .maplibregl-popup-close-button:hover {
-        background: var(--bg-tertiary);
-        color: var(--text-primary);
+    .maplibregl-popup.themed-popup {
+        overflow: visible;
+        max-width: none !important;
     }
 
     .popup-container {
+        display: flex;
+        align-items: flex-start;
         color: var(--text-primary);
         font-family: 'Roboto', sans-serif;
         transition: color 0.3s ease;
     }
 
+    .popup-main {
+        min-width: 320px;
+        max-width: 380px;
+        background: var(--bg-primary);
+        border: 1px solid var(--border-primary);
+        border-radius: 12px;
+        box-shadow: 0 4px 20px var(--shadow);
+        flex-shrink: 0;
+        position: relative;
+        transition: border-radius 0.3s ease, background-color 0.3s ease, border-color 0.3s ease;
+    }
+
+    .popup-main.side-open {
+        border-radius: 12px 0 0 12px;
+        border-right: none;
+    }
+
     .popup-header {
-        padding: 20px 20px 16px 20px;
+        padding: 16px 20px;
         border-bottom: 1px solid var(--border-secondary);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
         transition: border-color 0.3s ease;
     }
 
     .popup-title {
         margin: 0;
-        font-size: 18px;
+        font-size: 16px;
         font-weight: 600;
         color: var(--text-primary);
-        transition: color 0.3s ease;
+    }
+
+    .popup-close-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        color: var(--text-secondary);
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .popup-close-btn:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+    }
+
+    .popup-close-btn i {
+        font-size: 18px;
     }
 
     .popup-content {
@@ -460,10 +586,176 @@
         border-color: var(--accent-hover);
     }
 
+    /* Coordinates slide toggle */
+    .toggle-coords-btn {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        width: 100%;
+        padding: 8px 12px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-primary);
+        border-radius: 8px;
+        color: var(--text-secondary);
+        font-size: 13px;
+        cursor: pointer;
+        transition: all 0.2s;
+    }
+
+    .toggle-coords-btn:hover {
+        color: var(--accent-primary);
+        border-color: var(--accent-primary);
+    }
+
+    .toggle-coords-btn i {
+        font-size: 18px;
+        transition: transform 0.2s;
+    }
+
+    .coords-side-panel {
+        width: 0;
+        overflow: hidden;
+        background: var(--bg-primary);
+        border-top: 1px solid var(--border-primary);
+        border-right: 1px solid var(--border-primary);
+        border-bottom: 1px solid var(--border-primary);
+        border-left: none;
+        border-radius: 0 12px 12px 0;
+        box-shadow: 4px 4px 20px var(--shadow);
+        flex-shrink: 0;
+        transition: width 0.3s ease;
+    }
+
+    .coords-side-panel.open {
+        width: 250px;
+    }
+
+    .coords-side-header {
+        padding: 16px 16px;
+        min-height: 28px;
+        display: flex;
+        align-items: center;
+        border-bottom: 1px solid var(--border-secondary);
+        box-sizing: content-box;
+    }
+
+    .coords-side-title {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .coords-side-body {
+        padding: 10px 12px 14px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .coords-col-headers {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        padding: 0 4px 2px;
+    }
+
+    .coords-spacer {
+        width: 22px;
+        flex-shrink: 0;
+    }
+
+    .coords-col-label {
+        flex: 1;
+        font-size: 10px;
+        color: var(--text-secondary);
+        font-weight: 500;
+    }
+
+    .coords-row {
+        display: flex;
+        gap: 6px;
+        align-items: center;
+        padding: 4px;
+        border-radius: 6px;
+        transition: background-color 0.15s;
+    }
+
+    .coords-row:hover {
+        background: var(--bg-secondary);
+    }
+
+    .coords-point-label {
+        width: 22px;
+        height: 22px;
+        line-height: 22px;
+        text-align: center;
+        font-size: 11px;
+        font-weight: 700;
+        border-radius: 4px;
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+        flex-shrink: 0;
+        transition: background-color 0.15s, color 0.15s;
+    }
+
+    .coords-row:hover .coords-point-label {
+        background: var(--accent-primary);
+        color: white;
+    }
+
+    .coords-input {
+        flex: 1;
+        min-width: 0;
+        padding: 5px 7px;
+        border: 1px solid var(--border-primary);
+        border-radius: 4px;
+        font-size: 11px;
+        font-family: monospace;
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        box-sizing: border-box;
+        transition: border-color 0.15s, box-shadow 0.15s;
+    }
+
+    .coords-input:focus {
+        outline: none;
+        border-color: var(--accent-primary);
+        box-shadow: 0 0 0 2px rgba(var(--accent-primary-rgb), 0.15);
+    }
+
+    /* Hide number spinners in popup */
+    .coords-input::-webkit-inner-spin-button,
+    .coords-input::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
+    .coords-input {
+        -moz-appearance: textfield;
+        appearance: textfield;
+    }
+
+    .save-coords-btn {
+        width: 100%;
+        padding: 7px;
+        margin-top: 6px;
+        background: var(--accent-primary);
+        color: white;
+        border: none;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background-color 0.2s;
+    }
+
+    .save-coords-btn:hover {
+        background: var(--accent-hover);
+    }
+
     .form-actions {
         display: flex;
         justify-content: flex-end;
-        margin-top: 8px;
+        padding: 0 20px 16px;
     }
 
     /* Material Icons in popup */

--- a/src/lib/vertex_labels.ts
+++ b/src/lib/vertex_labels.ts
@@ -1,0 +1,125 @@
+import maplibregl from 'maplibre-gl';
+import type { Map as MMap } from 'maplibre-gl';
+import type MapboxDraw from '@mapbox/mapbox-gl-draw';
+
+const LABELS = ['A', 'B', 'C', 'D'] as const;
+
+// featureId -> markers + last known color
+const managedFeatures = new Map<string, { markers: maplibregl.Marker[], color: string }>();
+
+function createLabelElement(label: string, color: string): HTMLDivElement {
+    const el = document.createElement('div');
+    el.textContent = label;
+    el.style.cssText = `
+        width: 20px;
+        height: 20px;
+        line-height: 20px;
+        text-align: center;
+        font-size: 11px;
+        font-weight: 700;
+        font-family: system-ui, sans-serif;
+        color: white;
+        background: ${color};
+        border: 2px solid white;
+        border-radius: 4px;
+        box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+        pointer-events: none;
+    `;
+    return el;
+}
+
+function removeFeatureLabels(featureId: string) {
+    const managed = managedFeatures.get(featureId);
+    if (managed) {
+        managed.markers.forEach(m => m.remove());
+        managedFeatures.delete(featureId);
+    }
+}
+
+function syncLabelsFromDraw(map: MMap, mdraw: MapboxDraw) {
+    const allFeatures = mdraw.getAll();
+    const activeIds = new Set<string>();
+
+    for (const feature of allFeatures.features) {
+        if (!feature.id || feature.geometry.type !== 'Polygon') continue;
+
+        const fid = String(feature.id);
+        activeIds.add(fid);
+
+        const ring = feature.geometry.coordinates[0];
+        if (!ring || ring.length < 2) continue;
+
+        const uniqueCount = ring.length - 1;
+        const labelCount = Math.min(4, uniqueCount);
+        if (labelCount < 1) continue;
+
+        const color = (feature.properties?.color_rgb_str as string) || '#666';
+        const existing = managedFeatures.get(fid);
+
+        if (existing && existing.markers.length === labelCount && existing.color === color) {
+            // Same count and color — just update positions
+            for (let i = 0; i < labelCount; i++) {
+                const [lng, lat] = ring[i];
+                if (isFinite(lng) && isFinite(lat)) {
+                    existing.markers[i].setLngLat([lng, lat]);
+                }
+            }
+        } else {
+            // Color changed, label count changed, or new feature — recreate
+            if (existing) {
+                existing.markers.forEach(m => m.remove());
+            }
+            const markers: maplibregl.Marker[] = [];
+            for (let i = 0; i < labelCount; i++) {
+                const [lng, lat] = ring[i];
+                if (!isFinite(lng) || !isFinite(lat)) continue;
+
+                const el = createLabelElement(LABELS[i], color);
+                const marker = new maplibregl.Marker({ element: el, anchor: 'center' })
+                    .setLngLat([lng, lat])
+                    .addTo(map);
+                markers.push(marker);
+            }
+            managedFeatures.set(fid, { markers, color });
+        }
+    }
+
+    // Remove labels for features no longer in draw
+    for (const fid of [...managedFeatures.keys()]) {
+        if (!activeIds.has(fid)) {
+            removeFeatureLabels(fid);
+        }
+    }
+}
+
+let boundMap: MMap | null = null;
+let boundDraw: MapboxDraw | null = null;
+
+function onDrawRender() {
+    if (boundMap && boundDraw) {
+        syncLabelsFromDraw(boundMap, boundDraw);
+    }
+}
+
+export function bindVertexLabels(map: MMap, mdraw: MapboxDraw) {
+    unbindVertexLabels();
+    boundMap = map;
+    boundDraw = mdraw;
+    map.on('draw.render', onDrawRender);
+    syncLabelsFromDraw(map, mdraw);
+}
+
+export function unbindVertexLabels() {
+    if (boundMap) {
+        boundMap.off('draw.render', onDrawRender);
+    }
+    clearAllVertexLabels();
+    boundMap = null;
+    boundDraw = null;
+}
+
+export function clearAllVertexLabels() {
+    for (const fid of [...managedFeatures.keys()]) {
+        removeFeatureLabels(fid);
+    }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -529,11 +529,12 @@
     }
 
     #left_workspace {
+        position: relative;
         width: 100%;
         background: var(--bg-secondary);
         display: grid;
         grid-auto-flow: row;
-        grid-template-areas: 
+        grid-template-areas:
             "A"
             "splitter"
             "B";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,6 +17,7 @@
 	import type { ZoneFeature, ZonesCollection } from '$lib/zones';
 	import { saveTOML } from '$lib/rest_api_mutations';
 	import { States, SubscriberState } from '$lib/states';
+	import { updateVertexLabels, clearAllVertexLabels } from '$lib/vertex_labels';
     import "../style.css";
     
     const { apiURL } = apiUrlStore
@@ -44,6 +45,10 @@
     $: mapFocused = (stateVariable === States.AddingZoneMap || stateVariable === States.DeletingZoneMap)
     $: dataStorageAll = [...$dataStorage].filter((element) => element[1].id)
     $: dataStorageLinked = dataStorageAll.filter((element) => element[1].properties.spatial_object_id)
+    // Update vertex labels A/B/C/D on map whenever dataStorage changes
+    $: if ($map && $dataStorage) {
+        updateVertexLabels($map, $dataStorage);
+    }
 
     const cancelActionTexts: Map<States, string> = new Map([
         [States.AddingZoneCanvas, 'Adding zone to the canvas'],
@@ -113,6 +118,7 @@
             if (unsubscribeCanvas) unsubscribeCanvas()
             if (unsubscribeGeoData) unsubscribeGeoData()
             clearDataStorage()
+            clearAllVertexLabels()
             if ($canvasState !== undefined && $canvasState != null) {
                 //@ts-ignore
                 $canvasState.getObjects().forEach( (contour: { unid: string; }) => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,7 +17,7 @@
 	import type { ZoneFeature, ZonesCollection } from '$lib/zones';
 	import { saveTOML } from '$lib/rest_api_mutations';
 	import { States, SubscriberState } from '$lib/states';
-	import { updateVertexLabels, clearAllVertexLabels } from '$lib/vertex_labels';
+	import { bindVertexLabels, unbindVertexLabels, clearAllVertexLabels } from '$lib/vertex_labels';
     import "../style.css";
     
     const { apiURL } = apiUrlStore
@@ -45,10 +45,6 @@
     $: mapFocused = (stateVariable === States.AddingZoneMap || stateVariable === States.DeletingZoneMap)
     $: dataStorageAll = [...$dataStorage].filter((element) => element[1].id)
     $: dataStorageLinked = dataStorageAll.filter((element) => element[1].properties.spatial_object_id)
-    // Update vertex labels A/B/C/D on map whenever dataStorage changes
-    $: if ($map && $dataStorage) {
-        updateVertexLabels($map, $dataStorage);
-    }
 
     const cancelActionTexts: Map<States, string> = new Map([
         [States.AddingZoneCanvas, 'Adding zone to the canvas'],
@@ -156,6 +152,7 @@
         }
         
         mapComponent.attachDraw($draw)
+        bindVertexLabels($map, $draw)
         $map.on("draw.create", function(e: DrawCreateEvent) {
             e.features[0].properties = {
                 color_rgb_str: EMPTY_POLYGON_RGB,
@@ -182,6 +179,7 @@
         console.log('Destroyed')
         canvasReady.set(false)
         dataReady.set(false)
+        unbindVertexLabels()
         unsubscribeCanvas()
         unsubscribeGeoData()
         unsubApiChange()

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,9 +42,8 @@
     let unsubscribeGeoData: Unsubscriber
     $: canvasFocused = (stateVariable === States.AddingZoneCanvas || stateVariable === States.DeletingZoneCanvas)
     $: mapFocused = (stateVariable === States.AddingZoneMap || stateVariable === States.DeletingZoneMap)
-    $: dataStorageFiltered = [...$dataStorage].filter((element)=> {
-        return (element[1].id && element[1].properties.spatial_object_id)
-    })
+    $: dataStorageAll = [...$dataStorage].filter((element) => element[1].id)
+    $: dataStorageLinked = dataStorageAll.filter((element) => element[1].properties.spatial_object_id)
 
     const cancelActionTexts: Map<States, string> = new Map([
         [States.AddingZoneCanvas, 'Adding zone to the canvas'],
@@ -305,7 +304,7 @@
         onDeleteFromCanvas={stateDelFromCanvas}
         onAddToMap={stateAddToMap}
         onDeleteFromMap={stateDelFromMap}
-        onSave={() => saveTOML(initialAPIURL, dataStorageFiltered)}
+        onSave={() => saveTOML(initialAPIURL, dataStorageLinked)}
     />
     <Switchers klass={canvasFocused || mapFocused ? 'blurred noselect' : ''}/>
     <div id="main_workspace" style="grid-template-columns: {leftPanelWidth}% 2px {100 - leftPanelWidth}%;">
@@ -327,7 +326,7 @@
                     <div></div> <!-- bottom line -->
                 </div>
             </div>
-            <ConfigurationStorage dataReady={dataReady} data={dataStorageFiltered} klass={!($canvasReady) || (canvasFocused || mapFocused) ? 'blurred noselect' : ''}/>
+            <ConfigurationStorage dataReady={dataReady} data={dataStorageAll} klass={!($canvasReady) || (canvasFocused || mapFocused) ? 'blurred noselect' : ''}/>
             <div class="overlay" style="{!canvasFocused && mapFocused ? 'display: block;' : 'display: none;'}">
                 Press ESC to cancel '{cancelActionText !== undefined? cancelActionText : cancelActionUnexpected}' mode
             </div>


### PR DESCRIPTION
Engineers who prepare map/canvas polygons often work with precise WGS84 coordinates from external sources (surveying tools, official documents, other GIS systems). Previously, the only way to position a zone was to draw a polygon on the map by hand - which doesn't provide the required accuracy. In this PR I'm trying to allow manual coordinate entry so engineers can type exact values directly.

So main changes are:
1) Zone list shows all zones.
Including those not yet placed on the map. Unlinked zones display a "Not linked" badge so it's clear which ones still need spatial binding.
2) Modal coordinate editor - each zone in the sidebar has an "Edit" button that opens a form with A/B/C/D vertex fields (lon/lat), lane direction and lane number. Hovering a vertex row highlights the corresponding point on the map.
3) Map popup coordinate editor - clicking a polygon on the map and pressing "Edit coordinates" slides out a compact panel to the right with the same A/B/C/D fields for quick in-place adjustments.
4) A/B/C/D vertex labels are now displayed on all map polygons in real time - during creation, dragging, and in view mode. Labels follow the zone color.

